### PR TITLE
feat: add entry content loading indicator

### DIFF
--- a/src/renderer/src/components/entry-column/index.tsx
+++ b/src/renderer/src/components/entry-column/index.tsx
@@ -187,7 +187,7 @@ const useEntriesByView = () => {
         null,
     [query.data],
   )
-  console.log("remoteEntryIds", remoteEntryIds)
+
   return {
     ...query,
 

--- a/src/renderer/src/components/entry-column/item-wrapper.tsx
+++ b/src/renderer/src/components/entry-column/item-wrapper.tsx
@@ -83,7 +83,7 @@ function EntryItemWrapperImpl({
   }
 
   return (
-    <div className={cn(!views[view || 0].wideMode && "pb-3")}>
+    <div className={cn(!views[view || 0].wideMode && "pb-3")} data-entry-id={entryId}>
       <div
         className={cn(
           "rounded-md bg-background transition-colors",

--- a/src/renderer/src/components/entry-content/index.tsx
+++ b/src/renderer/src/components/entry-content/index.tsx
@@ -6,6 +6,7 @@ import { useEntry, useFeedStore } from "@renderer/store"
 import { m } from "framer-motion"
 import { useEffect, useState } from "react"
 
+import { LoadingCircle } from "../ui/loading"
 import { EntryShare } from "./share"
 
 export const EntryContent = ({ entry }: { entry: ActiveEntry }) => {
@@ -32,7 +33,7 @@ export const EntryContent = ({ entry }: { entry: ActiveEntry }) => {
 }
 
 function EntryContentRender({ entryId }: { entryId: string }) {
-  useBizQuery(Queries.entries.byId(entryId), {
+  const { error } = useBizQuery(Queries.entries.byId(entryId), {
     staleTime: 300_000,
   })
 
@@ -79,6 +80,19 @@ function EntryContentRender({ entryId }: { entryId: string }) {
                 new Date(entry.entries.publishedAt).toUTCString()}
               </div>
             </a>
+
+            {!content && (
+              <div className="center mt-16">
+                {!error ? (
+                  <LoadingCircle size="large" />
+                ) : (
+                  <div className="center flex flex-col gap-2">
+                    <i className="i-mingcute-close-line text-3xl text-red-500" />
+                    <span className="font-sans text-sm">Network Error</span>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="prose prose-zinc mx-auto mb-32 mt-10 max-w-full cursor-auto select-text break-all text-[15px] dark:prose-invert">
               {content}
             </div>

--- a/src/renderer/src/components/ui/loading.tsx
+++ b/src/renderer/src/components/ui/loading.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@renderer/lib/utils"
+
+interface LoadingCircleProps {
+  size: "small" | "medium" | "large"
+}
+
+const sizeMap = {
+  small: "text-md",
+  medium: "text-xl",
+  large: "text-3xl",
+}
+export const LoadingCircle: Component<LoadingCircleProps> = ({
+  className,
+  size,
+}) => (
+  <div className={cn(sizeMap[size], className)}>
+    <i className="i-mingcute-loading-3-line animate-spin" />
+  </div>
+)


### PR DESCRIPTION

# Movataion

We currently use local data first, the server request will be slower than the local data loaded, so when press and view an entry, first render the local data that cached before, but the `content` may not cached (because in the entry list API, the `content` field is not included), so in this case, add a loading indicator.

# Video

https://github.com/RSSNext/follow/assets/41265413/39631bc5-d13b-4ea8-a638-b4e43adaf596

