### PR TITLE
fix: align logo again

### DIFF
--- a/src/renderer/src/modules/entry-column/index.tsx
+++ b/src/renderer/src/modules/entry-column/index.tsx
@@ -323,7 +323,7 @@ const EmptyList = forwardRef<HTMLDivElement, HTMLMotionProps<"div">>(
 
     return (
       <m.div
-        className="-mt-20 flex h-full flex-col items-center justify-center gap-2 text-zinc-400"
+        className="-mt-6 flex h-full flex-col items-center justify-center gap-2 text-zinc-400"
         {...props}
         ref={ref}
       >


### PR DESCRIPTION
The logo's in the wrong place again, fix it again!

![CleanShot 2024-06-17 at 5  37 33@2x](https://github.com/RSSNext/follow/assets/41265413/d1a81e46-dc76-40be-9baa-29187d84ed6e)
