### PR TITLE
fix(web): can not enter settings, hide disabled title

### DIFF
--- a/src/renderer/src/modules/settings/setting-builder.tsx
+++ b/src/renderer/src/modules/settings/setting-builder.tsx
@@ -26,7 +26,7 @@ type CustomSettingItem = ReactNode | FC
 export const createSettingBuilder =
   <T extends object>(useSetting: () => T) =>
     <K extends keyof T>(props: {
-      settings: (SettingItem<T, K> | SpecificSettingItem | CustomSettingItem | false)[]
+      settings: (SettingItem<T, K> | SpecificSettingItem | CustomSettingItem | boolean)[]
     }) => {
       const { settings } = props
       const settingObject = useSetting()

--- a/src/renderer/src/modules/settings/setting-builder.tsx
+++ b/src/renderer/src/modules/settings/setting-builder.tsx
@@ -26,56 +26,59 @@ type CustomSettingItem = ReactNode | FC
 export const createSettingBuilder =
   <T extends object>(useSetting: () => T) =>
     <K extends keyof T>(props: {
-      settings: (SettingItem<T, K> | SpecificSettingItem | CustomSettingItem)[]
+      settings: (SettingItem<T, K> | SpecificSettingItem | CustomSettingItem | false)[]
     }) => {
       const { settings } = props
       const settingObject = useSetting()
 
-      return settings.map((setting, index) => {
-        if (isValidElement(setting)) return setting
-        if (typeof setting === "function") return React.createElement(setting)
-        const assertSetting = setting as SettingItem<T> | SpecificSettingItem
+      return settings
+        .filter((i) => typeof i !== "boolean")
+        .map((setting, index) => {
+          if (isValidElement(setting)) return setting
+          if (typeof setting === "function") return React.createElement(setting)
+          const assertSetting = setting as SettingItem<T> | SpecificSettingItem
 
-        if (
-          "type" in assertSetting &&
-          assertSetting.type === "title" &&
-          assertSetting.value
-        ) {
-          return <SettingSectionTitle key={index} title={assertSetting.value} />
-        }
-        if ("type" in assertSetting) {
-          return null
-        }
+          if (assertSetting.disabled) return null
 
-        if (assertSetting.disabled) return null
-        let ControlElement: React.ReactNode
-        switch (typeof settingObject[assertSetting.key]) {
-          case "boolean": {
-            ControlElement = (
-              <SettingSwitch
-                className="mt-4"
-                checked={settingObject[assertSetting.key] as boolean}
-                onCheckedChange={(checked) =>
-                  assertSetting.onChange(checked as T[keyof T])}
-                label={assertSetting.label}
-              />
-            )
-            break
+          if (
+            "type" in assertSetting &&
+            assertSetting.type === "title" &&
+            assertSetting.value
+          ) {
+            return <SettingSectionTitle key={index} title={assertSetting.value} />
           }
-          case "string": {
+          if ("type" in assertSetting) {
             return null
           }
-          default: {
-            return null
+
+          let ControlElement: React.ReactNode
+          switch (typeof settingObject[assertSetting.key]) {
+            case "boolean": {
+              ControlElement = (
+                <SettingSwitch
+                  className="mt-4"
+                  checked={settingObject[assertSetting.key] as boolean}
+                  onCheckedChange={(checked) =>
+                    assertSetting.onChange(checked as T[keyof T])}
+                  label={assertSetting.label}
+                />
+              )
+              break
+            }
+            case "string": {
+              return null
+            }
+            default: {
+              return null
+            }
           }
-        }
-        return (
-          <SettingItemGroup key={index}>
-            {ControlElement}
-            {!!assertSetting.description && (
-              <SettingDescription>{assertSetting.description}</SettingDescription>
-            )}
-          </SettingItemGroup>
-        )
-      })
+          return (
+            <SettingItemGroup key={index}>
+              {ControlElement}
+              {!!assertSetting.description && (
+                <SettingDescription>{assertSetting.description}</SettingDescription>
+              )}
+            </SettingItemGroup>
+          )
+        })
     }


### PR DESCRIPTION
Currently, you can not enter the appearance section in web settings.

![ScreenShot 2024-07-11 06 31 07](https://github.com/RSSNext/follow/assets/38493346/10818f58-4eb8-4378-a440-023a8b77923a)

I also hide the unavailable setting group.

![ScreenShot 2024-07-11 06 32 15](https://github.com/RSSNext/follow/assets/38493346/30c4e2a9-113a-456b-8bed-617eb09c65c4)
