### PR TITLE
feat: dont shink unread when query refreshed

### DIFF
--- a/src/renderer/src/initialize/hydrate.ts
+++ b/src/renderer/src/initialize/hydrate.ts
@@ -26,6 +26,11 @@ export const setHydrated = (v: boolean) => {
   _isHydrated = v
 }
 
+/**
+ * @description Check if database data is hydrated to store, or current database is ready.
+ * If users disabled data persist, it's always false, that means you can't do operation with database.
+ *
+ */
 export const isHydrated = () => _isHydrated
 
 export const hydrateDatabaseToStore = async () => {

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -146,3 +146,13 @@ export const pluralize = (
   }
   return postfix(noun, rule)
 }
+
+export const omitObjectUndefinedValue = (obj: Record<string, any>) => {
+  const newObj = {}
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      newObj[key] = obj[key]
+    }
+  }
+  return newObj
+}

--- a/src/renderer/src/store/entry/store.ts
+++ b/src/renderer/src/store/entry/store.ts
@@ -99,6 +99,11 @@ class EntryActions {
         const entry = draft.flatMapEntries[entryId]
         if (!entry) return
         Object.assign(entry, changed)
+        if (changed.read !== undefined && changed.read !== null) {
+          EntryService.bulkStoreReadStatus({
+            [entryId]: changed.read,
+          })
+        }
         return draft
       }),
     )

--- a/src/renderer/src/store/entry/store.ts
+++ b/src/renderer/src/store/entry/store.ts
@@ -1,5 +1,8 @@
 import { apiClient } from "@renderer/lib/api-fetch"
-import { getEntriesParams } from "@renderer/lib/utils"
+import {
+  getEntriesParams,
+  omitObjectUndefinedValue,
+} from "@renderer/lib/utils"
 import type {
   CombinedEntryModel,
   EntryModel,
@@ -7,7 +10,7 @@ import type {
 } from "@renderer/models"
 import { EntryService } from "@renderer/services"
 import { produce } from "immer"
-import { merge, omit } from "lodash-es"
+import { isNil, merge, omit } from "lodash-es"
 
 import { isHydrated } from "../../initialize/hydrate"
 import { feedActions } from "../feed"
@@ -98,12 +101,8 @@ class EntryActions {
       produce(state, (draft) => {
         const entry = draft.flatMapEntries[entryId]
         if (!entry) return
-        Object.assign(entry, changed)
-        if (changed.read !== undefined && changed.read !== null) {
-          EntryService.bulkStoreReadStatus({
-            [entryId]: changed.read,
-          })
-        }
+        Object.assign(entry, omitObjectUndefinedValue(changed))
+
         return draft
       }),
     )
@@ -209,6 +208,12 @@ class EntryActions {
     this.patch(entryId, {
       read,
     })
+    if (!isHydrated()) return
+    if (!isNil(read)) {
+      EntryService.bulkStoreReadStatus({
+        [entryId]: read,
+      })
+    }
   }
 
   markReadByFeedId(feedId: string) {


### PR DESCRIPTION
When the query for the entry list is refreshed, retain the read entries that have already been rendered in the unread list.