### PR TITLE
feat: read count

### DIFF
--- a/icons/mgc/eye_2_cute_re.svg
+++ b/icons/mgc/eye_2_cute_re.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none"><path fill="#fff" fill-opacity=".01" d="M24 0v24H0V0z"/><path stroke="#10161F" stroke-width="2" d="M21 12c0 3-4.03 6.5-9 6.5S3 15 3 12s4.03-6.5 9-6.5S21 9 21 12Z"/><path stroke="#10161F" stroke-width="2" d="M14 12a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"/></svg>


### PR DESCRIPTION

<img width="739" alt="image" src="https://github.com/user-attachments/assets/1bb7e597-237a-4d8d-aef1-4eae745e44ef">


For this feature, optimistic update rendering is executed within the UI layer rather than the queries layer due to the utilization of the read data mutation in certain instances via react query and in others through the patch method within the data store. This disparity significantly complicates the endeavor of maintaining data consistency. It may be necessary to address this issue at a later time.

The original approach undertaken was outlined as follows for renference:

<img width="573" alt="image" src="https://github.com/user-attachments/assets/b03aaf9e-b9dd-40cc-bafc-c9dc334d1043">
