### PR TITLE
fix: inline image style

### DIFF
--- a/src/renderer/src/components/ui/markdown/renderers/BlockImage.tsx
+++ b/src/renderer/src/components/ui/markdown/renderers/BlockImage.tsx
@@ -17,7 +17,7 @@ export const MarkdownBlockImage = (
         size.w < Number.parseInt(props.width as string) && "w-full",
       )}
       popper
-      className="flex justify-center"
+      className="inline-flex justify-center"
     />
   )
 }


### PR DESCRIPTION
In other APP

![ScreenShot 2024-07-28 16 45 23](https://github.com/user-attachments/assets/564c294a-ab5d-4d47-8845-68c4120e7a5f)

Before

![ScreenShot 2024-07-28 16 42 16](https://github.com/user-attachments/assets/7393c91e-c9a5-4c5f-9100-743ad81ed861)

After

![ScreenShot 2024-07-28 16 43 14](https://github.com/user-attachments/assets/f1b48eee-342f-4ea2-9855-49ac1c3973b1)

This shouldn't affect the image styling of other entries?

![ScreenShot 2024-07-28 16 44 42](https://github.com/user-attachments/assets/4f68bfb6-02c9-499c-920f-195d69ad2833)


