### PR TITLE
fix: button component with asChild

### DIFF
--- a/src/renderer/src/components/ui/button/index.tsx
+++ b/src/renderer/src/components/ui/button/index.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "@radix-ui/react-slot"
+import { Slot, Slottable } from "@radix-ui/react-slot"
 import { stopPropagation } from "@renderer/lib/dom"
 import { cn } from "@renderer/lib/utils"
 import type { VariantProps } from "class-variance-authority"
@@ -55,7 +55,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {isLoading && (
           <i className="i-mgc-loading-3-cute-re mr-2 animate-spin" />
         )}
-        {props.children}
+        <Slottable>{props.children}</Slottable>
       </Comp>
     )
   },
@@ -72,6 +72,7 @@ interface ActionButtonProps {
   active?: boolean
   shortcut?: string
   as?: keyof React.JSX.IntrinsicElements
+  asChild?: boolean
 }
 
 export const ActionButton = React.forwardRef<
@@ -89,6 +90,7 @@ export const ActionButton = React.forwardRef<
       active,
       shortcut,
       as,
+      asChild,
     },
     ref,
   ) => {
@@ -107,6 +109,7 @@ export const ActionButton = React.forwardRef<
           <TooltipTrigger asChild>
             <Button
               as={as}
+              asChild={asChild}
               ref={buttonRef}
               // @see https://github.com/radix-ui/primitives/issues/2248#issuecomment-2147056904
               onFocusCapture={stopPropagation}

--- a/src/renderer/src/modules/settings/tabs/about.tsx
+++ b/src/renderer/src/modules/settings/tabs/about.tsx
@@ -94,17 +94,16 @@ export const SettingAbout = () => (
       <div className="mt-2 flex flex-wrap gap-2">
         {SocialMediaLinks.map((link) => (
           <Button
-            as="a"
+            asChild
             key={link.url}
             variant="outline"
             className="flex flex-1 cursor-pointer items-center gap-2"
-            // @ts-expect-error
-            href={link.url}
-            target="_blank"
-            rel="noreferrer"
+
           >
-            <i className={link.icon} />
-            {link.label}
+            <a href={link.url} target="_blank" rel="noreferrer">
+              <i className={link.icon} />
+              {link.label}
+            </a>
           </Button>
         ))}
       </div>


### PR DESCRIPTION
This pr uses `asChid` to remove unsafe ts-expect-error directive in the about page.

This pull request also fixes errors when using `asChild` in the button component.

<img width="714" alt="Screenshot 2024-07-28 at 19 09 11" src="https://github.com/user-attachments/assets/be6fd3ca-cab9-4e8e-af8e-f24760bead77">

```
Error: React.Children.only expected to receive a single React element child.
```

The loading function also works normally.

<img width="723" alt="Screenshot 2024-07-28 at 19 13 06" src="https://github.com/user-attachments/assets/fc62e24d-f2b0-4ff3-bb39-6f4e64fb1919">



Refer to https://github.com/shadcn-ui/ui/issues/3117
