### PR TITLE
style: reset the EntryReadHistory line-height

### DIFF
--- a/src/renderer/src/modules/entry-content/header.tsx
+++ b/src/renderer/src/modules/entry-content/header.tsx
@@ -57,7 +57,7 @@ export function EntryHeader({
     >
       <div
         className={cn(
-          "invisible absolute left-5 top-0 z-0 flex h-full items-center gap-2 text-[13px] text-zinc-500",
+          "invisible absolute left-5 top-0 z-0 flex h-full items-center gap-2 text-[13px] leading-none text-zinc-500",
           isAtTop && "visible z-[11]",
         )}
       >


### PR DESCRIPTION
`text-lg` can affect `line-height`, causing avatar groups to be too close to the top
reset it with `leading-none`

Before: 
![image](https://github.com/user-attachments/assets/3f976c5d-be87-4353-ac2f-ec7ccfb3d7c6)

After: 
![image](https://github.com/user-attachments/assets/c00c39be-4255-44bb-be06-d95616d733d5)
