### PR TITLE
build: making universal build for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,12 +80,17 @@ jobs:
         run: pnpm i
 
       - name: Build
+        if: matrix.os != 'macos-latest'
+        run: pnpm build
+
+      - name: Build (macOS)
+        if: matrix.os == 'macos-latest'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           KEYCHAIN_PATH: ${{ runner.temp }}/app-signing.keychain-db
-        run: pnpm build
+        run: pnpm build:macos
 
       - name: Upload file
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "./dist/main/index.js",
   "scripts": {
     "build": "npm run typecheck && electron-vite build --outDir=dist && electron-forge make",
+    "build:macos": "npm run typecheck && electron-vite build --outDir=dist && electron-forge make --arch=universal --platform=darwin",
     "build:web": "vite build",
     "dev": "electron-vite dev --outDir=dist",
     "dev:debug": "export DEBUG=true && vite --debug",


### PR DESCRIPTION
Make build work for Intel-based Mac.

Note: The introduced `build:macos` script requires OSX signing and won't function without it. Refer to https://github.com/electron/forge/issues/3271 for details. **I was not able to create a test build due to this issue.** I would appreciate it if the maintainers could assist in testing this before merging. This shouldn't be a problem on GH Action as signing is properly configured.