### PR TITLE
fix: fix style when image and name both empty

### DIFF
--- a/src/renderer/src/components/feed-icon.tsx
+++ b/src/renderer/src/components/feed-icon.tsx
@@ -94,7 +94,7 @@ export function FeedIcon({
               } as any
             }
             className={cn(
-              "mr-2 inline-flex shrink-0 items-center justify-center rounded-sm text-xs font-medium",
+              "mr-2 flex shrink-0 items-center justify-center rounded-sm text-xs font-medium",
               "bg-[var(--fo-light-background)] text-white dark:bg-[var(--fo-dark-background)] dark:text-black",
               className,
             )}


### PR DESCRIPTION
Search Link: 
https://www.developerway.com/rss.xml

Before:
<img width="255" alt="image" src="https://github.com/user-attachments/assets/6e49de70-04e1-4eb0-a61f-21d641239036">

After:
<img width="235" alt="image" src="https://github.com/user-attachments/assets/27ad9443-c772-4205-ac54-1220c3d3e57d">
