### PR TITLE
fix: use official embed player in bilibili video when use web

### DIFF
--- a/src/renderer/src/lib/url-to-iframe.ts
+++ b/src/renderer/src/lib/url-to-iframe.ts
@@ -1,6 +1,9 @@
 export const urlToIframe = (url?: string | null, mini?: boolean) => {
   if (url?.match(/\/\/www.bilibili.com\/video\/BV\w+/)) {
-    return `https://www.bilibili.com/blackboard/newplayer.html?${new URLSearchParams({
+    const player = window.electron ?
+      "https://www.bilibili.com/blackboard/newplayer.html" :
+      "https://player.bilibili.com/player.html"
+    return `${player}?${new URLSearchParams({
       isOutside: "true",
       autoplay: "true",
       danmaku: "true",


### PR DESCRIPTION
This pull request fixes the issue where the embed player will check `window.REFERRER_LIST` by `PlayerUtil.isCertifiedReferrer()` and throw `[Permission] Not Allowed` error.

