### PR TITLE
fix: subcription status & input component warning

### DIFF
--- a/src/renderer/src/modules/discover/feed-form.tsx
+++ b/src/renderer/src/modules/discover/feed-form.tsx
@@ -140,7 +140,7 @@ const FeedInnerForm = ({
   useEffect(() => {
     if (subscription) {
       form.setValue("view", `${subscription?.view}`)
-      form.setValue("category", subscription?.category)
+      subscription?.category && form.setValue("category", subscription.category)
       form.setValue("isPrivate", subscription?.isPrivate || false)
     }
   }, [subscription])

--- a/src/renderer/src/modules/profile/user-profile-modal.tsx
+++ b/src/renderer/src/modules/profile/user-profile-modal.tsx
@@ -377,6 +377,7 @@ const SubscriptionItem: FC<{
                 content: ({ dismiss }) => (
                   <FeedForm
                     asWidget
+                    id={subscription.feedId}
                     url={subscription.feeds.url}
                     defaultValues={{
                       view: defaultView.toString(),


### PR DESCRIPTION
Fixed the issue where subscription was active, but still showed as unsubscribed in the Profile.

Before:
<img width="677" alt="image" src="https://github.com/user-attachments/assets/0519be08-93a4-433a-b6da-51034e10ad6a">

After:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/27660698-97f5-4ba5-97e3-b30120b2d3e2">

And fixed the warning of the input component when the Category is null

Befor:
![image](https://github.com/user-attachments/assets/11d745aa-2d25-43a3-a15d-5c7c5af01456)
