### PR TITLE
fix: profile fields are not updated after modifying the profile

### DIFF
--- a/src/renderer/src/pages/settings/(settings)/profile.tsx
+++ b/src/renderer/src/pages/settings/(settings)/profile.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useWhoami } from "@renderer/atoms/user"
+import { setWhoami, useWhoami } from "@renderer/atoms/user"
 import { Button } from "@renderer/components/ui/button"
 import {
   Form,
@@ -51,7 +51,10 @@ export function Component() {
       apiClient["auth-app"]["update-account"].$patch({
         json: values,
       }),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
+      if (user && variables) {
+        setWhoami({ ...user, ...variables })
+      }
       toast("Profile updated.", {
         duration: 3000,
       })
@@ -109,7 +112,12 @@ export function Component() {
             )}
           />
           <div className="text-right">
-            <Button type="submit">Submit</Button>
+            <Button
+              type="submit"
+              isLoading={updateMutation.isPending}
+            >
+              Submit
+            </Button>
           </div>
         </form>
       </Form>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. After modifying the profile, switching to the settings tab will display the old data before the modification.
2. The submit button is missing a load animation

### Linked Issues


### Additional context

Before:

https://github.com/user-attachments/assets/e5aaa80c-0d73-4f26-a7c8-3d2c11e3d0e0

After:


https://github.com/user-attachments/assets/64f1e01c-9797-47a1-921a-41e830920cce

