### PR TITLE
UI Improvement: make readed article color into gray

### DIFF
--- a/src/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/src/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -88,7 +88,10 @@ export function ListItem({
             <EntryTranslation
               useOverlay
               side="top"
-              className={envIsSafari ? "line-clamp-2 break-all" : undefined}
+              className={cn(
+                envIsSafari ? "line-clamp-2 break-all" : undefined,
+                asRead ? "text-zinc-400 dark:text-neutral-500" : undefined,
+              )}
               source={entry.entries.title}
               target={translation?.title}
             />


### PR DESCRIPTION
### Description

Make readed article title into gray.

**Before: title will not be gray after read**
<img width="713" alt="image" src="https://github.com/user-attachments/assets/58683c3c-a1dd-4900-8b62-e474f5b49d9e">
**After: title wil be gray after read**
<img width="623" alt="image" src="https://github.com/user-attachments/assets/c55c1931-4c40-46eb-9ccb-8dc936530a42">


### Linked Issues

### Additional context

