### PR TITLE
chore: add whitespace before license in about page

### DIFF
--- a/src/renderer/src/modules/settings/tabs/about.tsx
+++ b/src/renderer/src/modules/settings/tabs/about.tsx
@@ -37,7 +37,7 @@ export const SettingAbout = () => (
       </div>
 
       <p className="mt-6 text-balance text-sm">
-        {APP_NAME} is and will always be a free and open-source project. It is licensed under
+        {APP_NAME} is and will always be a free and open-source project. It is licensed under{" "}
         {license}.
       </p>
       <p className="mt-3 text-balance text-sm">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Add whitespace before LICENSE in about page

|before|after|
|:--:|:--:|
|![image](https://github.com/user-attachments/assets/55939960-6d2a-43d2-86e3-2535cfcd5e1b)|![image](https://github.com/user-attachments/assets/42ce900c-27e5-4181-9740-4b6498d99166)|

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
