### PR TITLE
fix: incorrect tooltip in read history

### DIFF
--- a/src/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
+++ b/src/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
@@ -1,6 +1,11 @@
 import { useWhoami } from "@renderer/atoms/user"
 import { Avatar, AvatarFallback, AvatarImage } from "@renderer/components/ui/avatar"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@renderer/components/ui/tooltip"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from "@renderer/components/ui/tooltip"
 import { useAuthQuery } from "@renderer/hooks/common"
 import { Queries } from "@renderer/queries"
 import { useEntryReadHistory } from "@renderer/store/entry"
@@ -63,7 +68,9 @@ export const EntryReadHistory: Component<{ entryId: string }> = ({ entryId }) =>
                 </span>
               </div>
             </TooltipTrigger>
-            <TooltipContent side="top">More</TooltipContent>
+            <TooltipPortal>
+              <TooltipContent side="top">More</TooltipContent>
+            </TooltipPortal>
           </Tooltip>
         )}
     </div>
@@ -101,7 +108,9 @@ const EntryUser: Component<{
           </Avatar>
         </m.button>
       </TooltipTrigger>
-      <TooltipContent side="top">Recent reader: {user.name}</TooltipContent>
+      <TooltipPortal>
+        <TooltipContent side="top">Recent reader: {user.name}</TooltipContent>
+      </TooltipPortal>
     </Tooltip>
   )
 })


### PR DESCRIPTION
This PR fixes the incorrect usage in the tooltip in the read history.

Before

<img width="268" alt="Screenshot 2024-09-14 at 00 59 09" src="https://github.com/user-attachments/assets/a86aedf7-0669-46fc-a7ed-4c084c35f2f5">

After

<img width="286" alt="Screenshot 2024-09-14 at 00 59 30" src="https://github.com/user-attachments/assets/31f70136-d80f-4f1c-8262-36561bde1686">
