### PR TITLE
feat: prompt the full categories when editing the feed

### DIFF
--- a/src/renderer/src/modules/discover/feed-form.tsx
+++ b/src/renderer/src/modules/discover/feed-form.tsx
@@ -248,7 +248,7 @@ const FeedInnerForm = ({
 
   const { t } = useTranslation()
 
-  const categories = useAuthQuery(subscriptionQuery.categories(Number.parseInt(form.watch("view"))))
+  const categories = useAuthQuery(subscriptionQuery.categories())
 
   // useEffect(() => {
   //   if (feed.isSuccess) nextFrame(() => buttonRef.current?.focus());

--- a/src/renderer/src/queries/subscriptions.ts
+++ b/src/renderer/src/queries/subscriptions.ts
@@ -12,7 +12,7 @@ export const subscription = {
   categories: (view?: number) =>
     defineQuery(["subscription-categories", view], async () => {
       const res = await apiClient.categories.$get({
-        query: { view: String(view) },
+        query: { view: view ? String(view) : undefined },
       })
 
       return res.data


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When editing the feed's category, the suggestion list only shows the categories from the current feed's view. If you want to use category names from other views, you have to re-enter them. This PR is intended to display categories from all views in the suggestions

### Linked Issues
#391 

### Additional context
before:
![CleanShot 2024-09-14 at 14 45 55@2x](https://github.com/user-attachments/assets/805e92b2-04ae-41e5-8684-520f872929c8)


after:
![CleanShot 2024-09-14 at 14 44 26@2x](https://github.com/user-attachments/assets/8b3021b5-b7b0-419d-b8ef-e9345f1a52a4)


<!-- e.g. is there anything you'd like reviewers to focus on? -->
