### PR TITLE
fix: read history always show

### DIFF
--- a/src/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
+++ b/src/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
@@ -61,7 +61,7 @@ export const EntryReadHistory: Component<{ entryId: string }> = ({ entryId }) =>
         entryHistory.readCount > 10 &&
         entryHistory.userIds &&
         entryHistory.userIds.length >= 10 && (
-          <HoverCard open>
+          <HoverCard>
             <HoverCardTrigger asChild>
               <button
                 type="button"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

it is a bug from https://github.com/RSSNext/Follow/pull/377

it should be open when the mouse hover, but it always show now.

![image](https://github.com/user-attachments/assets/64d275c5-64d3-45e3-894a-d22adf8e72bd)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
