### PR TITLE
fix: empty default font on electron app

### DIFF
--- a/apps/renderer/src/modules/settings/sections/fonts.tsx
+++ b/apps/renderer/src/modules/settings/sections/fonts.tsx
@@ -27,10 +27,12 @@ const useFontDataElectron = () => {
     queryKey: ["systemFonts"],
   })
 
-  return [FALLBACK_FONT].concat(data || []).map((font) => ({
-    label: font,
-    value: font,
-  }))
+  return [{ label: FALLBACK_FONT, value: "inherit" }].concat(
+    (data || []).map((font) => ({
+      label: font,
+      value: font,
+    })),
+  )
 }
 
 const useFontDataWeb = () => [


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

![Screenshot 2024-09-18 at 21 20 40](https://github.com/user-attachments/assets/87a46c5e-d73a-4729-9db2-e696dbf69df0)

The default selected value of Content Font is empty.

Only on the Follow app.

### Linked Issues

/


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
