### PR TITLE
fix: crashes when docs appear in the discover result

### DIFF
--- a/apps/renderer/src/components/feed-icon.tsx
+++ b/apps/renderer/src/components/feed-icon.tsx
@@ -150,7 +150,7 @@ export function FeedIcon({
 
       ImageElement = (
         <PlatformIcon
-          url={feed?.siteUrl!}
+          url={feed?.siteUrl || fallbackUrl}
           style={sizeStyle}
           className={cn("center mr-2", className)}
         >

--- a/apps/renderer/src/components/ui/platform-icon/index.tsx
+++ b/apps/renderer/src/components/ui/platform-icon/index.tsx
@@ -16,17 +16,17 @@ const IconMap = Object.values(LinkParsers).reduce(
 
 const shouldAddWhiteBgUrls = ["1x.com"]
 export const PlatformIcon: FC<{
-  url: string
+  url?: string
   children: React.JSX.Element
   className?: string
   style?: React.CSSProperties
 }> = ({ className, url, children, style, ...rest }) => {
-  const iconName = getSupportedPlatformIconName(url)
+  const iconName = url && getSupportedPlatformIconName(url)
 
-  if (!iconName || !IconMap[iconName]) {
+  if (!iconName || !IconMap[iconName] || !url) {
     return (
       <Slot
-        className={`${shouldAddWhiteBgUrls.some((_) => url.includes(_)) ? "bg-white" : ""} ${className}`}
+        className={`${url && shouldAddWhiteBgUrls.some((_) => url.includes(_)) ? "bg-white" : ""} ${className}`}
         style={style}
         {...rest}
       >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I was importing github releases but it crashed the discover page

<img width="717" alt="image" src="https://github.com/user-attachments/assets/e690c451-511c-4aea-8966-fe542ef8efdc">

It seems the issue is caused by the `docs` type item.

This PR makes it compatible with the `docs` type item.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
