### PR TITLE
fix: ensure unique keys for search items

### DIFF
--- a/apps/renderer/src/modules/panel/cmdk.tsx
+++ b/apps/renderer/src/modules/panel/cmdk.tsx
@@ -166,7 +166,7 @@ export const SearchCmdK: React.FC = () => {
                   const feed = getFeedById(entry.feedId)
                   return (
                     <SearchItem
-                      key={entry.item.id}
+                      key={`entry-${entry.item.id}-${entry.feedId}`}
                       view={feed?.id ? getSubscriptionByFeedId(feed.id)?.view : undefined}
                       title={entry.item.title!}
                       feedId={entry.feedId}
@@ -191,7 +191,7 @@ export const SearchCmdK: React.FC = () => {
               >
                 {renderedFeeds.map((feed) => (
                   <SearchItem
-                    key={feed.item.id}
+                    key={`feed-${feed.item.id}`}
                     view={getSubscriptionByFeedId(feed.item.id!)?.view}
                     title={feed.item.title!}
                     feedId={feed.item.id!}
@@ -246,7 +246,8 @@ const SearchItem = memo(function Item({
         "min-w-0 max-w-full",
         styles["content-visually"],
       )}
-      key={id}
+      key={`${id}-${feedId}-${entryId}`}
+      id={`${id}-${feedId}-${entryId}`}
       onSelect={() => {
         navigateEntry({
           feedId: feedId!,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
I found that in the search results of the search panel, if there are duplicate items (possibly because an RSS author deleted and then republished an article), it causes abnormal hover styles with the mouse.

I changed the value of the key to make it less likely to repeat, in order to avoid this situation.

https://github.com/user-attachments/assets/69453c9e-2b3f-4f36-8ed4-513bb3c9cf9c


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
