### PR TITLE
fix: should use markdown to render link in rsshub parameter desc

### DIFF
--- a/apps/renderer/src/modules/discover/DiscoverFeedForm.tsx
+++ b/apps/renderer/src/modules/discover/DiscoverFeedForm.tsx
@@ -245,7 +245,9 @@ export const DiscoverFeedForm = ({
                 />
               )}
               {!!parameters && (
-                <p className="text-xs text-theme-foreground/50">{parameters.description}</p>
+                <Markdown className="text-xs text-theme-foreground/50">
+                  {parameters.description}
+                </Markdown>
               )}
             </FormItem>
           )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

use `<Markdown />` to render rsshub route desc link preview

#### Before

![CleanShot 2024-09-19 at 16 58 52@2x](https://github.com/user-attachments/assets/89b7f8ad-ef45-4220-8976-d10eb1f00231)

#### After

![CleanShot 2024-09-19 at 17 00 11@2x](https://github.com/user-attachments/assets/bf382b5d-22cd-4d81-987f-2555619f8c7d)

