### PR TITLE
fix: audioCover animation and estimatedMins style

### DIFF
--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -256,7 +256,7 @@ function AudioCover({
 
       {!!estimatedMins && (
         <div className="absolute bottom-0 w-full overflow-hidden rounded-b-sm text-center ">
-          <div className="z--1 absolute  left-0 top-0 size-full bg-white/50 opacity-0 duration-200 group-hover:opacity-100 dark:bg-neutral-900/70" />
+          <div className="absolute left-0 top-0 size-full bg-white/50 opacity-0 duration-200 group-hover:opacity-100 dark:bg-neutral-900/70" />
           <div className="text-[13px] opacity-0 backdrop-blur-none duration-200 group-hover:opacity-100 group-hover:backdrop-blur-sm">
             {formatEstimatedMins(estimatedMins)}
           </div>

--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -235,7 +235,7 @@ function AudioCover({
 
       <div
         className={cn(
-          "center absolute inset-0 w-full transition-all duration-200 ease-in-out group-hover:opacity-100",
+          "center absolute inset-0 w-full transition-all duration-200 ease-in-out group-hover:-translate-y-2 group-hover:opacity-100",
           playStatus ? "opacity-100" : "opacity-0",
         )}
         onClick={handleClickPlay}
@@ -255,8 +255,11 @@ function AudioCover({
       </div>
 
       {!!estimatedMins && (
-        <div className="absolute bottom-0 w-full rounded-b-sm bg-white/50 text-center text-[13px] opacity-0 backdrop-blur duration-100 group-hover:opacity-100 dark:bg-neutral-900/70">
-          {formatEstimatedMins(estimatedMins)}
+        <div className="absolute bottom-0 w-full overflow-hidden rounded-b-sm text-center ">
+          <div className="z--1 absolute  left-0 top-0 size-full bg-white/50 opacity-0 duration-200 group-hover:opacity-100 dark:bg-neutral-900/70" />
+          <div className="text-[13px] opacity-0 backdrop-blur-none duration-200 group-hover:opacity-100 group-hover:backdrop-blur-sm">
+            {formatEstimatedMins(estimatedMins)}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
1. fix estimatedMins style can see in   https://meanc.cc/backdrop-blur-dao-zhi-yuan-jiao-ju-chi
2. adjust animation with the button


https://github.com/user-attachments/assets/9662092f-761c-4055-b3d1-0cec12ea8247




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
