### PR TITLE
fix: position of swiper navigation buttons

### DIFF
--- a/apps/renderer/src/components/ui/media/preview-media.tsx
+++ b/apps/renderer/src/components/ui/media/preview-media.tsx
@@ -174,7 +174,7 @@ export const PreviewMediaContent: FC<{
             <div
               tabIndex={-1}
               onClick={stopPropagation}
-              className="center fixed bottom-4 left-1/2 h-6 gap-2 rounded-full bg-neutral-700/90 px-4 duration-200 animate-in fade-in-0 slide-in-from-bottom-6"
+              className="center fixed bottom-4 left-1/2 -translate-x-1/2 h-6 gap-2 rounded-full bg-neutral-700/90 px-4 duration-200 animate-in fade-in-0 slide-in-from-bottom-6"
             >
               {Array.from({ length: media.length })
                 .fill(0)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix the position of navigation buttons in media swiper.

#### before

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/0330e3a5-58c8-4057-a5b0-00548432e055">

#### after

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/08da6a43-6046-4667-b3b2-efc1dfc4e729">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

None

### Additional context

None

<!-- e.g. is there anything you'd like reviewers to focus on? -->
