### PR TITLE
refactor: deprecate hsl legacy syntax

### DIFF
--- a/apps/renderer/src/lib/color.ts
+++ b/apps/renderer/src/lib/color.ts
@@ -7,8 +7,8 @@ const getRandomColor = (lightness: [number, number], saturation: [number, number
   const lightBackground = lightAccent < 80 ? lightAccent + 20 : 100
 
   return {
-    accent: `hsl(${hue}, ${satAccent}%, ${lightAccent}%)`,
-    background: `hsl(${hue}, ${satBackground}%, ${lightBackground}%)`,
+    accent: `hsl(${hue} ${satAccent}% ${lightAccent}%)`,
+    background: `hsl(${hue} ${satBackground}% ${lightBackground}%)`,
   }
 }
 

--- a/apps/renderer/src/styles/colors.css
+++ b/apps/renderer/src/styles/colors.css
@@ -1,47 +1,47 @@
 [data-theme="light"] {
-  --fo-a: 21.6, 100%, 50%;
+  --fo-a: 21.6 100% 50%;
 
   --fo-vibrancy-background: theme(colors.native.active);
-  --fo-vibrancy-foreground: 0, 0%, 45%;
+  --fo-vibrancy-foreground: 0 0% 45%;
 
-  --fo-text-primary: 0, 0%, 10%;
+  --fo-text-primary: 0 0% 10%;
 
   --fo-item-active: theme(colors.zinc.400/0.3);
   --fo-item-hover: theme(colors.zinc.400/0.2);
 
-  --fo-inactive: 0, 0%, 80%;
-  --fo-disabled: 0, 0%, 70%;
+  --fo-inactive: 0 0% 80%;
+  --fo-disabled: 0 0% 70%;
 
   --fo-background: theme(colors.background);
 
   --fo-modal-background: theme(colors.zinc.50/0.8);
   --fo-modal-background-opaque: theme(colors.zinc.50);
 
-  --fo-text-primary-hover: 0, 0%, 14.9%;
+  --fo-text-primary-hover: 0 0% 14.9%;
 
   --fo-button-hover: theme(colors.zinc.500/0.1);
 }
 
 [data-theme="dark"] {
-  --fo-a: 21.6, 100%, 50%;
+  --fo-a: 21.6 100% 50%;
 
-  --fo-vibrancy-foreground: 0, 0%, 83%;
+  --fo-vibrancy-foreground: 0 0% 83%;
   --fo-vibrancy-background: theme(colors.native.active);
 
-  --fo-text-primary: 0, 0%, 80%;
+  --fo-text-primary: 0 0% 80%;
 
   --fo-item-active: theme(colors.neutral.600/0.4);
   --fo-item-hover: theme(colors.neutral.700/0.3);
 
-  --fo-inactive: 0, 0%, 50%;
-  --fo-disabled: 0, 0%, 35%;
+  --fo-inactive: 0 0% 50%;
+  --fo-disabled: 0 0% 35%;
 
   --fo-background: theme(colors.background);
 
   --fo-modal-background: theme(colors.neutral.900/0.8);
   --fo-modal-background-opaque: theme(colors.neutral.900);
 
-  --fo-text-primary-hover: 240, 4.9%, 83.9%;
+  --fo-text-primary-hover: 240 4.9% 83.9%;
 
   --fo-button-hover: theme(colors.neutral.400/0.15);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -72,7 +72,7 @@ export default resolveConfig({
             950: "#461304",
           },
 
-          vibrancyFg: "hsl(var(--fo-vibrancy-foreground), <alpha-value>)",
+          vibrancyFg: "hsl(var(--fo-vibrancy-foreground) / <alpha-value>)",
           vibrancyBg: "var(--fo-vibrancy-background)",
 
           item: {
@@ -80,13 +80,13 @@ export default resolveConfig({
             hover: "var(--fo-item-hover)",
           },
 
-          inactive: "hsl(var(--fo-inactive), <alpha-value>)",
-          disabled: "hsl(var(--fo-disabled), <alpha-value>)",
+          inactive: "hsl(var(--fo-inactive) / <alpha-value>)",
+          disabled: "hsl(var(--fo-disabled) / <alpha-value>)",
 
-          foreground: "hsl(var(--fo-text-primary), <alpha-value>)",
+          foreground: "hsl(var(--fo-text-primary) / <alpha-value>)",
           background: "var(--fo-background)",
 
-          "foreground-hover": "hsl(var(--fo-text-primary-hover), <alpha-value>)",
+          "foreground-hover": "hsl(var(--fo-text-primary-hover) / <alpha-value>)",
 
           modal: {
             background: "var(--fo-modal-background)",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Follow mixes modern HSL syntax with legacy syntax. This can result in invalid values like `hsl(h, s, l / alpha)` or `hsl(h s l, alpha)` when using CSS variables and the Tailwind theme.

This PR deprecates all hsl legacy syntax from the codebase.

### Linked Issues

https://github.com/user-attachments/assets/0766ad2f-4f66-432a-a7a1-616c25938355

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
