### PR TITLE
fix: allow cancel proxy configuration

### DIFF
--- a/apps/main/src/lib/proxy.ts
+++ b/apps/main/src/lib/proxy.ts
@@ -16,10 +16,10 @@ import { store } from "./store"
 
 export const setProxyConfig = (inputProxy: string) => {
   const proxyUri = normalizeProxyUri(inputProxy)
+  store.set("proxy", proxyUri)
   if (!proxyUri) {
     return false
   }
-  store.set("proxy", inputProxy)
   return true
 }
 


### PR DESCRIPTION
Blame to https://github.com/RSSNext/Follow/pull/452

This PR introduces the ability to cancel the proxy configuration when user input empty string.