### PR TITLE
fix: remove duplicated en and tweak lang sort

### DIFF
--- a/apps/renderer/src/@types/constants.ts
+++ b/apps/renderer/src/@types/constants.ts
@@ -1,8 +1,9 @@
-const langs = [
+export const currentSupportedLanguages = [
   "en",
   "ja",
   "zh-CN",
   "zh-TW",
+  "zh-HK",
   "pt",
   "fr",
   "ar-DZ",
@@ -11,13 +12,12 @@ const langs = [
   "ar-IQ",
   "ar-KW",
   "ar-TN",
-  "zh-HK",
   "fi",
   "it",
   "ru",
   "es",
 ]
-export const currentSupportedLanguages = ["en", ...langs.sort()]
+
 export const dayjsLocaleImportMap = {
   en: ["en", () => import("dayjs/locale/en")],
   ["zh-CN"]: ["zh-cn", () => import("dayjs/locale/zh-cn")],


### PR DESCRIPTION
This PR removes the duplicated English language and adjusts the sorting of the supported languages for better organization.

Before

<img width="598" alt="Screenshot 2024-09-22 at 00 25 17" src="https://github.com/user-attachments/assets/3ffc9b1c-3dfe-44c0-ab0e-cb4f22d29642">

<img width="306" alt="Screenshot 2024-09-22 at 00 25 09" src="https://github.com/user-attachments/assets/f252ce5b-5932-4288-9a05-976ad581c991">


After

<img width="588" alt="Screenshot 2024-09-22 at 00 24 44" src="https://github.com/user-attachments/assets/1aabf935-330d-4659-8b90-54ac070bddc8">
