### PR TITLE
fix: prevent translation popup from being obscured by time display

### DIFF
--- a/apps/renderer/src/modules/entry-column/translation.tsx
+++ b/apps/renderer/src/modules/entry-column/translation.tsx
@@ -50,7 +50,7 @@ export const EntryTranslation: Component<{
       <HoverCard.Portal>
         <HoverCard.Content
           className={cn(
-            "group relative text-sm",
+            "group relative z-[1] text-sm",
             "animate-in fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           )}
           style={useOverlay ? { width: bounds.width } : undefined}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
prevent translation popup from being obscured by time display
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
 #625 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
