### PR TITLE
style: fix the FloatMutedButton mispositioning

### DIFF
--- a/apps/renderer/src/components/ui/media.tsx
+++ b/apps/renderer/src/components/ui/media.tsx
@@ -17,6 +17,7 @@ const failedList = new Set<string | undefined>()
 type BaseProps = {
   mediaContainerClassName?: string
   showFallback?: boolean
+  thumbnail?: boolean
 }
 export type MediaProps = BaseProps &
   (
@@ -45,6 +46,7 @@ const MediaImpl: FC<MediaProps> = ({
   proxy,
   popper = false,
   mediaContainerClassName,
+  thumbnail,
   ...props
 }) => {
   const { src, style, type, previewImageUrl, showFallback, ...rest } = props
@@ -133,7 +135,7 @@ const MediaImpl: FC<MediaProps> = ({
             )}
             onClick={handleClick}
           >
-            <VideoPreview src={src!} previewImageUrl={previewImageUrl} />
+            <VideoPreview src={src!} previewImageUrl={previewImageUrl} thumbnail={thumbnail} />
           </span>
         )
       }
@@ -222,7 +224,8 @@ const FallbackMedia: FC<MediaProps> = ({ type, mediaContainerClassName, classNam
 const VideoPreview: FC<{
   src: string
   previewImageUrl?: string
-}> = ({ src, previewImageUrl }) => {
+  thumbnail?: boolean
+}> = ({ src, previewImageUrl, thumbnail = false }) => {
   const [isInitVideoPlayer, setIsInitVideoPlayer] = useState(!previewImageUrl)
 
   const [videoRef, setVideoRef] = useState<VideoPlayerRef | null>(null)
@@ -249,7 +252,7 @@ const VideoPreview: FC<{
         />
       ) : (
         <VideoPlayer
-          variant="preview"
+          variant={thumbnail ? "thumbnail" : "preview"}
           controls={false}
           src={src}
           ref={setVideoRef}

--- a/apps/renderer/src/components/ui/media.tsx
+++ b/apps/renderer/src/components/ui/media.tsx
@@ -230,6 +230,7 @@ const VideoPreview: FC<{
   const [forceUpdate] = useForceUpdate()
   return (
     <div
+      className="size-full"
       onMouseEnter={() => {
         videoRef?.controls.play()?.then(forceUpdate)
       }}

--- a/apps/renderer/src/components/ui/media/VideoPlayer.tsx
+++ b/apps/renderer/src/components/ui/media/VideoPlayer.tsx
@@ -34,7 +34,7 @@ import { VolumeSlider } from "./VolumeSlider"
 type VideoPlayerProps = {
   src: string
 
-  variant?: "preview" | "player"
+  variant?: "preview" | "player" | "thumbnail"
 } & React.VideoHTMLAttributes<HTMLVideoElement> &
   PropsWithChildren
 export type VideoPlayerRef = {
@@ -58,7 +58,7 @@ interface VideoPlayerContextValue {
   controls: VideoPlayerRef["controls"]
   wrapperRef: React.RefObject<HTMLDivElement>
   src: string
-  variant: "preview" | "player"
+  variant: "preview" | "player" | "thumbnail"
 }
 const VideoPlayerContext = createContext<VideoPlayerContextValue>(null!)
 export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(

--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -182,6 +182,7 @@ export function ListItem({
 
       {withDetails && entry.entries.media?.[0] && (
         <Media
+          thumbnail
           src={entry.entries.media[0].url}
           type={entry.entries.media[0].type}
           previewImageUrl={entry.entries.media[0].preview_image_url}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the preview video is loaded for the first time, the mute icon flashes and misplaces

before:

https://github.com/user-attachments/assets/f80d9a36-084f-416e-a712-abb8689f04b8


after: 

https://github.com/user-attachments/assets/52f4d81b-1f15-46cf-b396-3a69f4414503


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
