### PR TITLE
fix: display white block if can't fetch preview video

### DIFF
--- a/apps/renderer/src/components/ui/media.tsx
+++ b/apps/renderer/src/components/ui/media.tsx
@@ -255,6 +255,7 @@ const VideoPreview: FC<{
           variant={thumbnail ? "thumbnail" : "preview"}
           controls={false}
           src={src}
+          poster={previewImageUrl}
           ref={setVideoRef}
           muted
           className="relative size-full object-cover"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

display white block if can't fetch preview video, so i add poster to video attribute

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#554 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://github.com/user-attachments/assets/b60f32a1-e899-4427-a9da-c5bbcbcc0b5e

[fixed.webm](https://github.com/user-attachments/assets/b18d00c6-36ff-4980-9493-a98411aab73b)
