### PR TITLE
fix: modify the Tooltip content of the list dates title

### DIFF
--- a/apps/renderer/src/components/ui/datetime/index.tsx
+++ b/apps/renderer/src/components/ui/datetime/index.tsx
@@ -9,6 +9,8 @@ import { stopPropagation } from "~/lib/dom"
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from "../tooltip"
 
 const formatTemplateString = "lll"
+const formatTemplateStringShort = "ll"
+
 const formatTime = (
   date: string | Date,
   relativeBeforeDay?: number,
@@ -141,7 +143,7 @@ export const RelativeDay = ({ date }: { date: Date }) => {
     }
   }, [date, language])
 
-  const formated = dayjs(date).format(formatTemplateString)
+  const formated = dayjs(date).format(formatTemplateStringShort)
   if (formated === dateString) {
     return <>{dateString}</>
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

修改列表時間標題的Tooltip内容，目前會顯示年月日和時間，但是時間永遠是 23：59
這個是一個 '天’ 的概念，我覺得只顯示年月日就行

---

Modify the Tooltip content of the list date headers. Currently, it shows the date and time, but the time is always 23:59. Since this represents a 'day' concept, I think showing just the date is sufficient.

![image](https://github.com/user-attachments/assets/6415a577-f555-461e-861e-ceecaef9baf1)

![image](https://github.com/user-attachments/assets/a8cfd7a5-95a0-4957-a460-6b90f28cd650)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
