### PR TITLE
feat(user-profile): smoother height switching

### DIFF
--- a/apps/renderer/src/modules/profile/user-profile-modal.tsx
+++ b/apps/renderer/src/modules/profile/user-profile-modal.tsx
@@ -234,7 +234,7 @@ export const UserProfileModalContent: FC<{
           <Fragment>
             <div
               className={cn(
-                "center m-12 mb-4 flex shrink-0 flex-col",
+                "center m-12 mb-4 flex shrink-0 flex-col duration-700",
                 isHeaderSimple ? "mt-3 flex-row" : "flex-col",
               )}
             >
@@ -242,7 +242,7 @@ export const UserProfileModalContent: FC<{
                 asChild
                 className={cn("aspect-square", isHeaderSimple ? "size-12" : "size-16")}
               >
-                <m.span layout>
+                <m.span layout transition={{ duration: 0.35 }}>
                   <AvatarImage
                     className="duration-200 animate-in fade-in-0"
                     asChild
@@ -255,6 +255,7 @@ export const UserProfileModalContent: FC<{
               </Avatar>
               <m.div
                 layout
+                transition={{ duration: 0.35 }}
                 className={cn(
                   "flex cursor-text select-text flex-col items-center",
                   isHeaderSimple ? "ml-8 items-start" : "",


### PR DESCRIPTION
### Description

When scrolling through the user interface, the styles of user titles switch abruptly. Perhaps we can make the transition smoother.


**Old**
![old](https://cdn.jsdelivr.net/gh/Konata33/oss@master/uPic/iShot_2024-09-27_23.01.57.gif)


**New**

![new](https://cdn.jsdelivr.net/gh/Konata33/oss@master/uPic/iShot_2024-09-27_23.05.32.gif)


### Linked Issues

### Additional context
