### PR TITLE
fix: ShortcutMode cannot be closed using shortcuts keys

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/hooks.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/hooks.tsx
@@ -64,6 +64,12 @@ export const useModalStack = (options?: ModalStackOptions) => {
   }
 }
 const actions = {
+  getTopModalStack() {
+    return jotaiStore.get(modalStackAtom)[0]
+  },
+  getModalStackById(id: string) {
+    return jotaiStore.get(modalStackAtom).find((item) => item.id === id)
+  },
   dismiss(id: string) {
     jotaiStore.set(modalStackAtom, (p) => p.filter((item) => item.id !== id))
   },

--- a/apps/renderer/src/modules/modal/shortcuts.tsx
+++ b/apps/renderer/src/modules/modal/shortcuts.tsx
@@ -81,16 +81,26 @@ const ShortcutModalContent = () => {
 }
 
 export const useShortcutsModal = () => {
-  const { present } = useModalStack()
+  const { present, dismiss, getModalStackById } = useModalStack()
+  const id = "shortcuts"
 
-  return useCallback(() => {
+  const showShortcutsModal = useCallback(() => {
     present({
       title: "Shortcuts",
+      id,
       overlay: false,
-      id: "shortcuts",
       content: () => <ShortcutModalContent />,
       CustomModalComponent: PlainModal,
       clickOutsideToDismiss: true,
     })
   }, [present])
+
+  return () => {
+    const shortcutsModal = getModalStackById(id)
+    if (shortcutsModal && shortcutsModal.modal) {
+      dismiss(id)
+      return
+    }
+    showShortcutsModal()
+  }
 }

--- a/apps/renderer/src/modules/modal/shortcuts.tsx
+++ b/apps/renderer/src/modules/modal/shortcuts.tsx
@@ -95,12 +95,12 @@ export const useShortcutsModal = () => {
     })
   }, [present])
 
-  return () => {
+  return useCallback(() => {
     const shortcutsModal = getModalStackById(id)
     if (shortcutsModal && shortcutsModal.modal) {
       dismiss(id)
       return
     }
     showShortcutsModal()
-  }
+  }, [dismiss, getModalStackById, showShortcutsModal])
 }


### PR DESCRIPTION
Using `H` to open shortcut mode, pressing `H` again cannot close it