### PR TITLE
fix: wrong opening status of newly added feed

### DIFF
--- a/apps/renderer/src/modules/feed-column/category.tsx
+++ b/apps/renderer/src/modules/feed-column/category.tsx
@@ -67,7 +67,7 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
   useEffect(() => {
     if (shouldOpen) {
       if (!open && view !== undefined && folderName) {
-        subscriptionActions.toggleCategoryOpenState(view, folderName)
+        subscriptionActions.changeCategoryOpenState(view, folderName, true)
       }
 
       const $items = itemsRef.current

--- a/apps/renderer/src/store/subscription/store.ts
+++ b/apps/renderer/src/store/subscription/store.ts
@@ -159,6 +159,14 @@ class SubscriptionActions {
     )
   }
 
+  changeCategoryOpenState(view: FeedViewType, category: string, status: boolean) {
+    set((state) =>
+      produce(state, (state) => {
+        state.categoryOpenStateByView[view][category] = status
+      }),
+    )
+  }
+
   expandCategoryOpenStateByView(view: FeedViewType, isOpen: boolean) {
     set((state) =>
       produce(state, (state) => {


### PR DESCRIPTION
https://github.com/RSSNext/Follow/pull/709#issuecomment-2382464274

A little later I'll look into whether there should be a better way to initialize the feed data for the default categories
@hyoban 