### PR TITLE
fix: grid mode for images and video content page, shadow not fully displayed when the mouse hovers over

### DIFF
--- a/apps/renderer/src/modules/entry-column/item.tsx
+++ b/apps/renderer/src/modules/entry-column/item.tsx
@@ -5,6 +5,7 @@ import { LoadingCircle } from "~/components/ui/loading"
 import { views } from "~/constants"
 import { useAuthQuery } from "~/hooks/common"
 import type { FeedViewType } from "~/lib/enum"
+import { FeedViewType as FeedViewTypeEnum } from "~/lib/enum"
 import { cn } from "~/lib/utils"
 import { Queries } from "~/queries"
 import type { FlatEntryModel } from "~/store/entry"
@@ -38,9 +39,17 @@ function EntryItemImpl({ entry, view }: { entry: FlatEntryModel; view?: number }
   )
 
   const Item: EntryListItemFC = getItemComponentByView(view as FeedViewType)
+  const overlayItemClassName =
+    view === FeedViewTypeEnum.Pictures || view === FeedViewTypeEnum.Videos ? "top-0" : ""
 
   return (
-    <EntryItemWrapper itemClassName={Item.wrapperClassName} entry={entry} view={view} overlay>
+    <EntryItemWrapper
+      itemClassName={Item.wrapperClassName}
+      entry={entry}
+      view={view}
+      overlay
+      overlayItemClassName={overlayItemClassName}
+    >
       <Item entryId={entry.entries.id} translation={translation.data} />
     </EntryItemWrapper>
   )

--- a/apps/renderer/src/modules/entry-column/item.tsx
+++ b/apps/renderer/src/modules/entry-column/item.tsx
@@ -39,10 +39,17 @@ function EntryItemImpl({ entry, view }: { entry: FlatEntryModel; view?: number }
   )
 
   const Item: EntryListItemFC = getItemComponentByView(view as FeedViewType)
-  const overlayItemClassName = (view === FeedViewTypeEnum.Pictures || view === FeedViewTypeEnum.Videos) ? "top-0" : ""
+  const overlayItemClassName =
+    view === FeedViewTypeEnum.Pictures || view === FeedViewTypeEnum.Videos ? "top-0" : ""
 
   return (
-    <EntryItemWrapper itemClassName={Item.wrapperClassName} entry={entry} view={view} overlay overlayItemClassName={overlayItemClassName}>
+    <EntryItemWrapper
+      itemClassName={Item.wrapperClassName}
+      entry={entry}
+      view={view}
+      overlay
+      overlayItemClassName={overlayItemClassName}
+    >
       <Item entryId={entry.entries.id} translation={translation.data} />
     </EntryItemWrapper>
   )

--- a/apps/renderer/src/modules/entry-column/item.tsx
+++ b/apps/renderer/src/modules/entry-column/item.tsx
@@ -39,17 +39,10 @@ function EntryItemImpl({ entry, view }: { entry: FlatEntryModel; view?: number }
   )
 
   const Item: EntryListItemFC = getItemComponentByView(view as FeedViewType)
-  const overlayItemClassName =
-    view === FeedViewTypeEnum.Pictures || view === FeedViewTypeEnum.Videos ? "top-0" : ""
+  const overlayItemClassName = (view === FeedViewTypeEnum.Pictures || view === FeedViewTypeEnum.Videos) ? "top-0" : ""
 
   return (
-    <EntryItemWrapper
-      itemClassName={Item.wrapperClassName}
-      entry={entry}
-      view={view}
-      overlay
-      overlayItemClassName={overlayItemClassName}
-    >
+    <EntryItemWrapper itemClassName={Item.wrapperClassName} entry={entry} view={view} overlay overlayItemClassName={overlayItemClassName}>
       <Item entryId={entry.entries.id} translation={translation.data} />
     </EntryItemWrapper>
   )

--- a/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -21,10 +21,11 @@ export const EntryItemWrapper: FC<
     entry: FlatEntryModel
     view?: number
     itemClassName?: string
+    overlayItemClassName?: string
     overlay?: boolean
     style?: React.CSSProperties
   } & PropsWithChildren
-> = ({ entry, view, overlay, children, itemClassName, style }) => {
+> = ({ entry, view, overlay, children, itemClassName, overlayItemClassName, style }) => {
   const { items } = useEntryActions({
     view,
     entry,
@@ -127,7 +128,10 @@ export const EntryItemWrapper: FC<
         onContextMenu={handleContextMenu}
       >
         {overlay ? (
-          <ListItemHoverOverlay isActive={isActive || isContextMenuOpen}>
+          <ListItemHoverOverlay
+            isActive={isActive || isContextMenuOpen}
+            className={overlayItemClassName}
+          >
             {children}
           </ListItemHoverOverlay>
         ) : (

--- a/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -128,10 +128,7 @@ export const EntryItemWrapper: FC<
         onContextMenu={handleContextMenu}
       >
         {overlay ? (
-          <ListItemHoverOverlay
-            isActive={isActive || isContextMenuOpen}
-            className={overlayItemClassName}
-          >
+          <ListItemHoverOverlay isActive={isActive || isContextMenuOpen} className={overlayItemClassName}>
             {children}
           </ListItemHoverOverlay>
         ) : (

--- a/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -128,7 +128,10 @@ export const EntryItemWrapper: FC<
         onContextMenu={handleContextMenu}
       >
         {overlay ? (
-          <ListItemHoverOverlay isActive={isActive || isContextMenuOpen} className={overlayItemClassName}>
+          <ListItemHoverOverlay
+            isActive={isActive || isContextMenuOpen}
+            className={overlayItemClassName}
+          >
             {children}
           </ListItemHoverOverlay>
         ) : (


### PR DESCRIPTION
In the grid browsing mode of images and on the video content display page, when the mouse hovers over an image, the shadow is not fully displayed and appears truncated at the top.
I identified that the issue was caused by the "inset-y-1" style in the 「ListItemHoverOverlay」 component.
As this is a foundational component, I opted not to modify it directly. Instead, I introduced an "overlayItemClassName" attribute to the 「EntryItemWrapper」 component to address the style issue.
<img width="465" alt="iShot_2024-09-29_13 45 17" src="https://github.com/user-attachments/assets/e1719a10-726e-4a99-bfff-3d1a06b9f0c1">
I had previously submitted a PR. Upon discovering that the manager had refactored the component I modified, so I closed the PR, made further adjustments, and resubmitted it.
previous PR:  https://github.com/RSSNext/Follow/pull/710