### PR TITLE
fix: truncate long title in dialog title

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -359,10 +359,9 @@ export const ModalInternal = memo(
                       onPointerDownCapture={handleDrag}
                       onPointerDown={handleResizeEnable}
                     >
-                      <Dialog.Title className="flex shrink-0 grow items-center gap-2 px-4 py-1 text-lg font-semibold">
+                      <Dialog.Title className="flex max-w-full shrink-0 grow items-center gap-2 px-4 py-1 text-lg font-semibold">
                         {icon && <span className="size-4">{icon}</span>}
-
-                        <span>{title}</span>
+                        <span className="truncate">{title}</span>
                       </Dialog.Title>
                       {canClose && (
                         <Dialog.DialogClose className="center p-2" tabIndex={1} onClick={close}>


### PR DESCRIPTION
This PR modifies the modal title component to truncate long titles, ensuring that they fit within the available space.

This change enhances the user interface by preventing overflow and maintaining a clean layout.

Before
<img width="997" alt="Screenshot 2024-09-30 at 21 22 47" src="https://github.com/user-attachments/assets/f22821b8-948b-4900-adc6-8ece8e4d3ea0">

After

<img width="1024" alt="Screenshot 2024-09-30 at 21 22 28" src="https://github.com/user-attachments/assets/d7ed5696-a322-4f8d-aa28-c39f527a42d4">
