### PR TITLE
fix: resolve content blur after modal dragged

### DIFF
--- a/apps/renderer/src/modules/settings/modal/layout.tsx
+++ b/apps/renderer/src/modules/settings/modal/layout.tsx
@@ -75,7 +75,7 @@ export function SettingModalLayout(
           scale: 0.96,
         }}
         className={cn(
-          "relative flex overflow-hidden rounded-xl rounded-br-none border border-border",
+          "relative flex rounded-xl rounded-br-none border border-border",
           !overlay && "shadow-perfect",
         )}
         style={resizeableStyle}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Fix two problems：
When the modal is moved
1、The content inside becomes blurred 
2、The button prompts are not displayed fully

https://github.com/user-attachments/assets/83dcfa68-2d49-4167-aedf-1ef6bc9b1763



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
