### PR TITLE
fix(styles): align the styles of SocialMediaItem and Skeleton

### DIFF
--- a/apps/renderer/src/modules/entry-column/Items/social-media-item.tsx
+++ b/apps/renderer/src/modules/entry-column/Items/social-media-item.tsx
@@ -206,9 +206,9 @@ const ActionBar = ({ entryId }: { entryId: string }) => {
 }
 
 export const SocialMediaItemSkeleton = (
-  <div className="relative m-auto w-[75ch] rounded-md bg-theme-background text-zinc-700 transition-colors dark:text-neutral-400">
+  <div className="relative m-auto w-[645px] rounded-md bg-theme-background text-zinc-700 transition-colors dark:text-neutral-400">
     <div className="relative">
-      <div className="group relative flex py-4 pl-3 pr-2">
+      <div className="group relative flex px-8 py-6">
         <Skeleton className="mr-2 size-9" />
         <div className="ml-2 min-w-0 flex-1">
           <div className="-mt-0.5 line-clamp-5 flex-1 text-sm">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
在社交媒体列表滚动时，能感知到骨架屏样式和卡片样式不一致。此 PR 为了对齐两者样式。

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
之前：
![image](https://github.com/user-attachments/assets/5bde48ca-cdad-492d-be57-a2fa0113e368)
![image](https://github.com/user-attachments/assets/e18db103-91f1-4fb9-b017-bc02df5f5f15)

之后：
![image](https://github.com/user-attachments/assets/b825942a-9296-43d2-b121-1e7a4130e84e)


