### PR TITLE
fix: alignment of the title style at the top of the right content page

### DIFF
--- a/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -66,16 +66,13 @@ export const EntryListHeader: FC<{
   const feed = useFeedById(routerParams.feedId)
   const isList = feed?.type === "list"
 
-  const titleStyleBasedView = ["pl-12", "pl-7", "pl-7", "pl-7", "px-5", "pl-12"]
-
   const containerRef = React.useRef<HTMLDivElement>(null)
 
   return (
     <div
       ref={containerRef}
       className={cn(
-        "mb-2 flex w-full flex-col pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out",
-        titleStyleBasedView[view],
+        "mb-2 flex w-full flex-col pl-7 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out",
       )}
     >
       <div className={cn("flex w-full", titleAtBottom ? "justify-end" : "justify-between")}>


### PR DESCRIPTION
the type title at the top of the right content page is misaligned across different subscription types.
in the "EntryListHeader" component, an array named "titleStyleBasedView" is defined to configure the padding for various subscription types.
I think this is unnecessary. I attempted to remove it and instead apply a consistent padding value of "pl-7".
<img width="849" alt="iShot_2024-10-02_22 55 00" src="https://github.com/user-attachments/assets/5bfbc71b-601f-4dae-8971-ce11f649d47b">
