### PR TITLE
fix: external layout header margin

### DIFF
--- a/apps/renderer/src/components/header.tsx
+++ b/apps/renderer/src/components/header.tsx
@@ -27,10 +27,10 @@ export function Header() {
   const scrollYState = useMotionValueToState(scrollY)
 
   return (
-    <header className="fixed inset-x-0 top-0 z-[99] px-5 py-2 lg:px-0">
+    <header className="fixed inset-x-0 top-0 z-[99] px-5 py-2 xl:px-0">
       <div className="relative mx-auto my-4 flex w-full max-w-[1240px] items-center justify-between">
         <div
-          className="absolute inset-0 z-0 -mx-3 -my-2 rounded-full bg-slate-50/80 backdrop-blur-lg dark:bg-neutral-900/80 lg:-mx-8"
+          className="absolute inset-0 z-0 -mx-3 -my-2 rounded-full bg-slate-50/80 backdrop-blur-lg dark:bg-neutral-900/80 xl:-mx-8"
           style={{
             opacity: scrollYState / 100,
           }}

--- a/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
+++ b/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
@@ -1,4 +1,3 @@
-
 import { FeedViewType } from "~/lib/enum"
 import { useEntryContentContext } from "~/modules/entry-content/hooks"
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`/profile/xxx` 和 `/feed/xxx` 路由下的 header 在 1024~1280px 的页面宽度下显示有点异常，看不到圆角和外边距：

![CleanShot 2024-10-03 at 23 39 32@2x](https://github.com/user-attachments/assets/afab165f-669b-4f88-97f0-929b7c541536)

可以在这里验证问题：https://app.follow.is/feed/41223694984583170

修复后：

![CleanShot 2024-10-03 at 23 53 58@2x](https://github.com/user-attachments/assets/a7cec3b1-3e83-4b28-950d-ef6759b6c9ec)




### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
