### PR TITLE
fix: setting modal should be resizable from bottomRight only

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/helper.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/helper.tsx
@@ -1,3 +1,4 @@
+import type { Enable } from "re-resizable"
 import type { Context, PropsWithChildren } from "react"
 import { memo, useContext } from "react"
 
@@ -6,4 +7,22 @@ export const InjectContext = (context: Context<any>) => {
   return memo(({ children }: PropsWithChildren) => (
     <context.Provider value={ctxValue}>{children}</context.Provider>
   ))
+}
+
+export function resizableOnly(...positions: (keyof Enable)[]) {
+  const enable: Enable = {
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+    topRight: false,
+    bottomRight: false,
+    bottomLeft: false,
+    topLeft: false,
+  }
+
+  for (const position of positions) {
+    enable[position] = true
+  }
+  return enable
 }

--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -24,6 +24,7 @@ import { AppErrorBoundary } from "~/components/common/AppErrorBoundary"
 import { SafeFragment } from "~/components/common/Fragment"
 import { m } from "~/components/common/Motion"
 import { ErrorComponentType } from "~/components/errors/enum"
+import { resizableOnly } from "~/components/ui/modal"
 import { ElECTRON_CUSTOM_TITLEBAR_HEIGHT, isElectronBuild } from "~/constants"
 import { useSwitchHotKeyScope } from "~/hooks/common"
 import { nextFrame, stopPropagation } from "~/lib/dom"
@@ -358,9 +359,7 @@ export const ModalInternal = memo(
                   }}
                 >
                   <ResizeSwitch
-                    enable={{
-                      bottomRight: true,
-                    }}
+                    enable={resizableOnly("bottomRight")}
                     onResizeStart={handleResizeEnable}
                     defaultSize={resizeDefaultSize}
                     className="flex grow flex-col"

--- a/apps/renderer/src/modules/settings/modal/layout.tsx
+++ b/apps/renderer/src/modules/settings/modal/layout.tsx
@@ -8,7 +8,7 @@ import { useUISettingSelector } from "~/atoms/settings/ui"
 import { m } from "~/components/common/Motion"
 import { Logo } from "~/components/icons/logo"
 import { LetsIconsResizeDownRightLight } from "~/components/icons/resize"
-import { useResizeableModal } from "~/components/ui/modal"
+import { resizableOnly, useResizeableModal } from "~/components/ui/modal"
 import { ElECTRON_CUSTOM_TITLEBAR_HEIGHT } from "~/constants"
 import { preventDefault } from "~/lib/dom"
 import { cn, getOS } from "~/lib/utils"
@@ -94,9 +94,7 @@ export function SettingModalLayout(
         <SettingContext.Provider value={defaultCtx}>
           <Resizable
             onResizeStart={handlePointDown}
-            enable={{
-              bottomRight: true,
-            }}
+            enable={resizableOnly("bottomRight")}
             style={{ ...resizeableStyle, position: "static" }}
             defaultSize={{
               width: 800,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

https://github.com/RSSNext/Follow/blob/5285ea4ad97cbf86a171d2c273d159d0e89fb7eb/apps/renderer/src/modules/settings/modal/layout.tsx?plain=1#L97-L99

If I don't get it wrong, these lines mean enable `bottomRight` only.

But as bokuweb/re-resizable said,

> If you want to permit only right direction resizing, set `{ top:false, right:true, bottom:false, left:false, topRight:false, bottomRight:false, bottomLeft:false, topLeft:false }`.

This PR makes `<Resizable>` enables `bottomRight` only.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
