### PR TITLE
refactor: make resizing more natural

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -109,12 +109,17 @@ export const ModalInternal = memo(
 
     const modalElementRef = useRef<HTMLDivElement>(null)
 
+    const dragController = useDragControls()
     const {
-      handlePointDown: handleResizeEnable,
+      handleResizeStop,
+      handleResizeStart,
+      relocateModal,
+      preferDragDir,
       isResizeable,
       resizeableStyle,
     } = useResizeableModal(modalElementRef, {
       enableResizeable: resizeable,
+      dragControls: dragController,
     })
     const animateController = useAnimationControls()
     useEffect(() => {
@@ -137,7 +142,6 @@ export const ModalInternal = memo(
         })
     }, [animateController])
 
-    const dragController = useDragControls()
     const handleDrag: PointerEventHandler<HTMLDivElement> = useCallback(
       (e) => {
         if (draggable) {
@@ -347,7 +351,7 @@ export const ModalInternal = memo(
                   onClick={stopPropagation}
                   onSelect={handleSelectStart}
                   onKeyUp={handleDetectSelectEnd}
-                  drag
+                  drag={draggable && (preferDragDir || draggable)}
                   dragControls={dragController}
                   dragElastic={0}
                   dragListener={false}
@@ -360,14 +364,15 @@ export const ModalInternal = memo(
                 >
                   <ResizeSwitch
                     enable={resizableOnly("bottomRight")}
-                    onResizeStart={handleResizeEnable}
+                    onResizeStart={handleResizeStart}
+                    onResizeStop={handleResizeStop}
                     defaultSize={resizeDefaultSize}
                     className="flex grow flex-col"
                   >
                     <div
                       className={"relative flex items-center"}
                       onPointerDownCapture={handleDrag}
-                      onPointerDown={handleResizeEnable}
+                      onPointerDown={relocateModal}
                     >
                       <Dialog.Title className="flex w-0 max-w-full grow items-center gap-2 px-4 py-1 text-lg font-semibold">
                         {icon && <span className="size-4">{icon}</span>}

--- a/apps/renderer/src/modules/settings/modal/layout.tsx
+++ b/apps/renderer/src/modules/settings/modal/layout.tsx
@@ -29,8 +29,17 @@ export function SettingModalLayout(
   const tab = useSettingTab()
   const elementRef = useRef<HTMLDivElement>(null)
   const edgeElementRef = useRef<HTMLDivElement>(null)
-  const { handlePointDown, isResizeable, resizeableStyle } = useResizeableModal(elementRef, {
+  const dragController = useDragControls()
+  const {
+    handleResizeStart,
+    handleResizeStop,
+    preferDragDir,
+    relocateModal,
+    isResizeable,
+    resizeableStyle,
+  } = useResizeableModal(elementRef, {
     enableResizeable: true,
+    dragControls: dragController,
   })
 
   useEffect(() => {
@@ -47,15 +56,14 @@ export function SettingModalLayout(
     draggable: state.modalDraggable,
     overlay: state.modalOverlay,
   }))
-  const dragController = useDragControls()
   const handleDrag: PointerEventHandler<HTMLDivElement> = useCallback(
     (e) => {
       if (draggable) {
         dragController.start(e)
-        handlePointDown()
+        relocateModal()
       }
     },
-    [dragController, draggable, handlePointDown],
+    [dragController, draggable, relocateModal],
   )
   const measureDragConstraints = useCallback((constraints: BoundingBox) => {
     if (getOS() === "Windows") {
@@ -80,7 +88,7 @@ export function SettingModalLayout(
         )}
         style={resizeableStyle}
         onContextMenu={preventDefault}
-        drag={draggable}
+        drag={draggable && (preferDragDir || draggable)}
         dragControls={dragController}
         dragListener={false}
         dragMomentum={false}
@@ -93,9 +101,9 @@ export function SettingModalLayout(
       >
         <SettingContext.Provider value={defaultCtx}>
           <Resizable
-            onResizeStart={handlePointDown}
+            onResizeStart={handleResizeStart}
+            onResizeStop={handleResizeStop}
             enable={resizableOnly("bottomRight")}
-            style={{ ...resizeableStyle, position: "static" }}
             defaultSize={{
               width: 800,
               height: 700,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Resizing is not that natural now.

For example, when we move the top handle, the box becomes shorter from bottom.

https://github.com/user-attachments/assets/bda13586-200b-4809-a070-3ea179bf91a7

This PR combines `resizing` and `dragging` when the user is `resizing` from `top` or `left` to make sure the box is resizing following the cursor. Screencast:

https://github.com/user-attachments/assets/4d9c15b9-52c0-46e6-a9c7-918d5a9dd9e1




### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
