### PR TITLE
fix: improve developing experience with Electron on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You need to fill in the required environment variables first.
 cp .env.example .env
 ```
 
-Then run:
+Then set `VITE_API_URL` to `https://api.follow.is` and run:
 
 ```sh
 pnpm run dev

--- a/apps/main/src/init.ts
+++ b/apps/main/src/init.ts
@@ -16,7 +16,9 @@ const appFolder = {
   prod: "Follow",
   dev: "Follow (dev)",
 }
-
+if (process.argv.length === 3 && process.argv[2].startsWith("follow-dev:")) {
+  process.env.NODE_ENV = "development"
+}
 const isDev = process.env.NODE_ENV === "development"
 
 /**


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, it is very inconvenient to develop with Electron on windows:
When developers run `pnpm run dev` in terminal, an electron instance will be started.
Then it alerts developer to login. After logging in in the opened browser, we are required to open `follow-dev://auth?token=xxx` in the browser to continue.

That's the problem. A separate electron instance will be started instead of using the already running one.
For the second instance, it does not have the environment variable needed to launch (including ELECTRON_RENDERER_URL and those in .env), which is loaded by the first instance but not passed to the second instance.

The essential question we need to address is why the second instance was initiated (why requestSingleInstanceLock not work).

So that's why. The second instance is launched by the system and not having the NODE_ENV configured to "development".
And it will make the second instance's appData directory to be `Follow` instead of `Follow (dev)`. Different appData directory means different instances.

So the solution is to check if the process is started with `follow-dev:` and set the NODE_ENV for it.

And now, we can develop with Electron on Windows very happily. 😁 (Remember set `VITE_API_URL` to `https://api.follow.is` in `.env` file)

### Linked Issues

#672, #778

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
