### PR TITLE
fix: monospace font always be NSimSun on Windows

### DIFF
--- a/apps/renderer/index.html
+++ b/apps/renderer/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="referrer" content="no-referrer" />


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

On Windows, there is a bug with the monospace font in Electron.

When the lang is set to "en", the monospace font will be "Consolas".
When the lang is set to "zh-CN" or not set, the monospace font will be "NSimSun".

Although NSimSun is a monospace font, it is not suitable for screen reading. And because it covers the chinese characters, it will make the fallback font not work as expected (Introduced in ff4d0af).

So I tried to set the default monospace font to "Consolas" (any font that only contains English characters) on Windows,
according to [Official Docs](https://www.electronjs.org/docs/latest/api/browser-window#:~:text=monospace%20string%20(optional)%20%2D%20Defaults%20to%20Courier%20New).

But it doesn't work. (Also seen [node.js - Electron doesn't respect `webPreferences.defaultFontFamily`? - Stack Overflow](https://stackoverflow.com/questions/55862153/electron-doesnt-respect-webpreferences-defaultfontfamily))

So I tried to set html lang to "en" according to [electron defaultFontFamily 中的坑-CSDN 博客](https://blog.csdn.net/weixin_42541311/article/details/135397522). Then, the default monospace font is corrected to "Consolas".

![image](https://github.com/user-attachments/assets/4614b4da-2fb3-4de0-9979-9903b7df21e1)

### Linked Issues

#594

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
