### PR TITLE
feat: add CopyButton for url Tooltip of the text content

### DIFF
--- a/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
+++ b/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "~/components/ui/code-highlighter"
 import { FeedViewType } from "~/lib/enum"
 import { useEntryContentContext } from "~/modules/entry-content/hooks"
 
@@ -41,6 +42,10 @@ export const MarkdownLink = (props: LinkProps) => {
         <TooltipPortal>
           <TooltipContent align="start" className="break-all" side="bottom">
             {populatedFullHref}
+            <CopyButton
+              value={populatedFullHref!}
+              className="ml-1 inline-block size-5 p-0.5 [&_i]:size-3"
+             />
           </TooltipContent>
         </TooltipPortal>
       )}

--- a/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
+++ b/apps/renderer/src/components/ui/markdown/renderers/MarkdownLink.tsx
@@ -45,7 +45,7 @@ export const MarkdownLink = (props: LinkProps) => {
             <CopyButton
               value={populatedFullHref!}
               className="ml-1 inline-block size-5 p-0.5 [&_i]:size-3"
-             />
+            />
           </TooltipContent>
         </TooltipPortal>
       )}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

add CopyButton for url Tooltip of the text content
sometimes need to copy this url to send to others, so I made this

**Before**
<img width="673" alt="iShot_2024-10-09_14 04 09" src="https://github.com/user-attachments/assets/d4f226c4-f33d-4e77-b37f-98ec97b2d436">

**After**
<img width="673" alt="iShot_2024-10-09_14 05 13" src="https://github.com/user-attachments/assets/142ca4ac-21ba-4a55-8451-d432a93d6ee0">


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
