### PR TITLE
fix: F12 cannot open devTools in development mode

### DIFF
--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -48,6 +48,13 @@ function bootstrap() {
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
   app.whenReady().then(() => {
+    // Default open or close DevTools by F12 in development
+    // and ignore CommandOrControl + R in production.
+    // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
+    app.on("browser-window-created", (_, window) => {
+      optimizer.watchWindowShortcuts(window)
+    })
+
     // Set app user model id for windows
     electronApp.setAppUserModelId(`re.${APP_PROTOCOL}`)
 
@@ -85,13 +92,6 @@ function bootstrap() {
         mainWindow = createMainWindow()
       }
       url && handleOpen(url)
-    })
-
-    // Default open or close DevTools by F12 in development
-    // and ignore CommandOrControl + R in production.
-    // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-    app.on("browser-window-created", (_, window) => {
-      optimizer.watchWindowShortcuts(window)
     })
 
     // for dev debug


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`browser-window-created` should be listened before calling `new BrowserWindow()`. Close #832 

### Linked Issues

#832 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
