### PR TITLE
chore: improve devtools font on Windows

### DIFF
--- a/apps/main/src/window.ts
+++ b/apps/main/src/window.ts
@@ -7,7 +7,7 @@ import { IMAGE_PROXY_URL, imageRefererMatches } from "@follow/shared/image"
 import type { BrowserWindowConstructorOptions } from "electron"
 import { BrowserWindow, screen, shell } from "electron"
 
-import { isDev, isMacOS, isWindows11 } from "./env"
+import { isDev, isMacOS, isWindows, isWindows11 } from "./env"
 import { getIconPath } from "./helper"
 import { registerContextMenu } from "./lib/context-menu"
 import { store } from "./lib/store"
@@ -140,6 +140,9 @@ export function createWindow(
   // Make it consistent with Chrome on Windows, instead of SimSun.
   // ref: [[Feature Request]: Add possibility to change DevTools font · Issue #42055 · electron/electron](https://github.com/electron/electron/issues/42055)
   window.webContents.on("devtools-opened", () => {
+    if (!isWindows) {
+      return
+    }
     const css = `
       :root {
           --source-code-font-family: consolas; // For code such as Elements panel

--- a/apps/main/src/window.ts
+++ b/apps/main/src/window.ts
@@ -136,27 +136,26 @@ export function createWindow(
     })
   })
 
-  // Change the default font-family and font-size of the devtools.
-  // Make it consistent with Chrome on Windows, instead of SimSun.
-  // ref: [[Feature Request]: Add possibility to change DevTools font · Issue #42055 · electron/electron](https://github.com/electron/electron/issues/42055)
-  window.webContents.on("devtools-opened", () => {
-    if (!isWindows) {
-      return
-    }
-    const css = `
-      :root {
-          --source-code-font-family: consolas; // For code such as Elements panel
-          --source-code-font-size: 13px;
-          --monospace-font-family: consolas; // For sidebar such as Event Listener Panel
-          --monospace-font-size: 13px;
-      }`
-    window.webContents.devToolsWebContents?.executeJavaScript(`
-      const overriddenStyle = document.createElement('style');
-      overriddenStyle.innerHTML = '${css.replaceAll("\n", " ")}';
-      document.body.append(overriddenStyle);
-      document.body.classList.remove('platform-windows');
-    `)
-  })
+  if (isWindows) {
+    // Change the default font-family and font-size of the devtools.
+    // Make it consistent with Chrome on Windows, instead of SimSun.
+    // ref: [[Feature Request]: Add possibility to change DevTools font · Issue #42055 · electron/electron](https://github.com/electron/electron/issues/42055)
+    window.webContents.on("devtools-opened", () => {
+      const css = `
+        :root {
+            --source-code-font-family: consolas; // For code such as Elements panel
+            --source-code-font-size: 13px;
+            --monospace-font-family: consolas; // For sidebar such as Event Listener Panel
+            --monospace-font-size: 13px;
+        }`
+      window.webContents.devToolsWebContents?.executeJavaScript(`
+        const overriddenStyle = document.createElement('style');
+        overriddenStyle.innerHTML = '${css.replaceAll("\n", " ")}';
+        document.body.append(overriddenStyle);
+        document.body.classList.remove('platform-windows');
+      `)
+    })
+  }
 
   registerContextMenu(window)
 

--- a/apps/main/src/window.ts
+++ b/apps/main/src/window.ts
@@ -135,6 +135,26 @@ export function createWindow(
       },
     })
   })
+
+  // Change the default font-family and font-size of the devtools.
+  // Make it consistent with Chrome on Windows, instead of SimSun.
+  // ref: [[Feature Request]: Add possibility to change DevTools font · Issue #42055 · electron/electron](https://github.com/electron/electron/issues/42055)
+  window.webContents.on("devtools-opened", () => {
+    const css = `
+      :root {
+          --source-code-font-family: consolas; // For code such as Elements panel
+          --source-code-font-size: 13px;
+          --monospace-font-family: consolas; // For sidebar such as Event Listener Panel
+          --monospace-font-size: 13px;
+      }`
+    window.webContents.devToolsWebContents?.executeJavaScript(`
+      const overriddenStyle = document.createElement('style');
+      overriddenStyle.innerHTML = '${css.replaceAll("\n", " ")}';
+      document.body.append(overriddenStyle);
+      document.body.classList.remove('platform-windows');
+    `)
+  })
+
   registerContextMenu(window)
 
   return window


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Change the default font-family and font-size of the devtools. Make it consistent with Chrome on Windows, instead of SimSun.

ref: [[Feature Request]: Add possibility to change DevTools font · Issue #42055 · electron/electron](https://github.com/electron/electron/issues/42055)

![image](https://github.com/user-attachments/assets/c31244c8-6877-4f7d-9ccc-7f99fe785d57)


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
