### PR TITLE
fix: Mouse click may briefly overlap with background elements

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/overlay.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/overlay.tsx
@@ -24,7 +24,7 @@ export const ModalOverlay = forwardRef(
         ref={ref}
         id="modal-overlay"
         className={cn(
-          "pointer-events-none fixed inset-0 z-[11] rounded-[var(--fo-window-radius)] bg-zinc-50/80 dark:bg-neutral-900/80",
+          "fixed inset-0 z-[11] rounded-[var(--fo-window-radius)] bg-zinc-50/80 dark:bg-neutral-900/80",
           blur && "backdrop-blur-sm",
           className,
         )}
@@ -32,6 +32,7 @@ export const ModalOverlay = forwardRef(
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         style={{ zIndex }}
+        onClick={(e) => e.stopPropagation()}
       />
     </RootPortal>
   ),


### PR DESCRIPTION
close #838
The reason for this is that when multiple modals were being displayed off-rotation, the old modal had pointer-events-none set so that clicks were not blocked.