### PR TITLE
fix: avatar element masking button

### DIFF
--- a/apps/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
+++ b/apps/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
@@ -61,7 +61,7 @@ export const EntryReadHistory: Component<{ entryId: string }> = ({ entryId }) =>
             <button
               type="button"
               style={{
-                right: `${LIMIT * 8}px`,
+                marginLeft: `-${LIMIT * 8}px`,
                 zIndex: LIMIT + 1,
               }}
               className="no-drag-region relative flex size-7 items-center justify-center rounded-full border border-border bg-muted ring-2 ring-background"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
The previous use of reletive & right resulted in the actual width of the element covering the button, causing it to be unclickable     
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
![Xnip2024-10-10_14-04-51](https://github.com/user-attachments/assets/825e893a-aaa2-4054-94c6-dd221e0b2210)


### Linked Issues
#843 
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
