### PR TITLE
fix: discover page's trending icon is offset.

### DIFF
--- a/apps/renderer/src/modules/trending/index.tsx
+++ b/apps/renderer/src/modules/trending/index.tsx
@@ -21,7 +21,7 @@ import type { FeedModel, Models } from "~/models"
 
 import { usePresentUserProfileModal } from "../profile/hooks"
 
-export const Trend = () => {
+export const Trend = ({ className }: { className?: string }) => {
   const { present } = useModalStack()
   const { t } = useTranslation()
   return (
@@ -39,6 +39,7 @@ export const Trend = () => {
           className={cn(
             "size-6 text-accent duration-200 hover:shadow-none",
             "absolute bottom-1 right-3",
+            className,
           )}
         >
           <i className="i-mgc-trending-up-cute-re" />

--- a/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
+++ b/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
@@ -72,7 +72,7 @@ export function Component() {
             </TabsTrigger>
           ))}
 
-          <Trend />
+          <Trend className="relative bottom-0 left-1.5" />
         </TabsList>
         {tabs.map((tab) => (
           <TabsContent key={tab.name} value={tab.value} className="mt-8">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

discover page's trending icon is offset.

https://github.com/user-attachments/assets/e31ecd0a-c543-4668-997d-62634613a11b



### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
