### PR TITLE
feat: support use default browser open source content

### DIFF
--- a/apps/renderer/src/atoms/settings/general.ts
+++ b/apps/renderer/src/atoms/settings/general.ts
@@ -7,6 +7,7 @@ import { createSettingAtom } from "./helper"
 const createDefaultSettings = (): GeneralSettings => ({
   // App
   appLaunchOnStartup: false,
+  useDefaultBrowserOpenSourceContent: false,
   language: "en",
   // Data control
   dataPersist: true,
@@ -42,6 +43,7 @@ export const subscribeShouldUseIndexedDB = (callback: (value: boolean) => void) 
 
 export const generalServerSyncWhiteListKeys: (keyof GeneralSettings)[] = [
   "appLaunchOnStartup",
+  "useDefaultBrowserOpenSourceContent",
   "dataPersist",
   "sendAnonymousData",
   "language",

--- a/apps/renderer/src/hooks/biz/useEntryActions.tsx
+++ b/apps/renderer/src/hooks/biz/useEntryActions.tsx
@@ -13,6 +13,7 @@ import {
   setReadabilityContent,
   setReadabilityStatus,
 } from "~/atoms/readability"
+import { useGeneralSettingKey } from "~/atoms/settings/general"
 import { useIntegrationSettingKey } from "~/atoms/settings/integration"
 import {
   setShowSourceContent,
@@ -166,6 +167,9 @@ export const useEntryActions = ({
   const enableInstapaper = useIntegrationSettingKey("enableInstapaper")
   const instapaperUsername = useIntegrationSettingKey("instapaperUsername")
   const instapaperPassword = useIntegrationSettingKey("instapaperPassword")
+  const useDefaultBrowserOpenSourceContent = useGeneralSettingKey(
+    "useDefaultBrowserOpenSourceContent",
+  )
 
   const checkEagle = useQuery({
     queryKey: ["check-eagle"],
@@ -396,6 +400,12 @@ export const useEntryActions = ({
         active: showSourceContent,
         onClick: () => {
           if (!populatedEntry.entries.url) return
+
+          if (useDefaultBrowserOpenSourceContent) {
+            window.open(populatedEntry.entries.url, "_blank")
+            return
+          }
+
           const viewPreviewInModal = [
             FeedViewType.SocialMedia,
             FeedViewType.Videos,
@@ -480,6 +490,7 @@ export const useEntryActions = ({
     showSourceContentModal,
     read,
     unread,
+    useDefaultBrowserOpenSourceContent,
   ])
 
   return {

--- a/apps/renderer/src/modules/settings/tabs/general.tsx
+++ b/apps/renderer/src/modules/settings/tabs/general.tsx
@@ -53,6 +53,10 @@ export const SettingGeneral = () => {
     setGeneralSetting("appLaunchOnStartup", checked)
   }, [])
 
+  const saveSourceContentSetting = useCallback((checked: boolean) => {
+    setGeneralSetting("useDefaultBrowserOpenSourceContent", checked)
+  }, [])
+
   const { present } = useModalStack()
 
   return (
@@ -72,6 +76,13 @@ export const SettingGeneral = () => {
             },
           }),
           LanguageSelector,
+          defineSettingItem("useDefaultBrowserOpenSourceContent", {
+            label: t("general.use_default_browser_open_source_content"),
+            disabled: !tipcClient,
+            onChange(value) {
+              saveSourceContentSetting(value)
+            },
+          }),
           {
             type: "title",
             value: t("general.timeline"),

--- a/locales/settings/ar-DZ.json
+++ b/locales/settings/ar-DZ.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "افتح النص الأصلي باستخدام المتصفح الافتراضي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط إلى Eagle' عند توفره.",
   "integration.eagle.enable.label": "تمكين",

--- a/locales/settings/ar-IQ.json
+++ b/locales/settings/ar-IQ.json
@@ -106,6 +106,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "افتح النص الأصلي باستخدام المتصفح الافتراضي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط إلى Eagle' عند توفره.",
   "integration.eagle.enable.label": "تمكين",

--- a/locales/settings/ar-KW.json
+++ b/locales/settings/ar-KW.json
@@ -106,6 +106,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "افتح النص الأصلي باستخدام المتصفح الافتراضي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط إلى Eagle' عند توفره.",
   "integration.eagle.enable.label": "تمكين",

--- a/locales/settings/ar-MA.json
+++ b/locales/settings/ar-MA.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "افتح النص الأصلي باستخدام المتصفح الافتراضي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط لـ Eagle' إلا كان متوفر.",
   "integration.eagle.enable.label": "تشغيل",

--- a/locales/settings/ar-SA.json
+++ b/locales/settings/ar-SA.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "استخدم المتصفح الافتراضي لفتح النص الأصلي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط في Eagle' عند توفره.",
   "integration.eagle.enable.label": "تمكين",

--- a/locales/settings/ar-TN.json
+++ b/locales/settings/ar-TN.json
@@ -106,6 +106,7 @@
   "general.sidebar_title": "عام",
   "general.timeline": "الجدول الزمني",
   "general.unread": "غير مقروء",
+  "general.use_default_browser_open_source_content": "افتح النص الأصلي باستخدام المتصفح الافتراضي",
   "general.voices": "الأصوات",
   "integration.eagle.enable.description": "عرض زر 'حفظ الوسائط إلى Eagle' عندما يكون متاحًا.",
   "integration.eagle.enable.label": "تمكين",

--- a/locales/settings/de.json
+++ b/locales/settings/de.json
@@ -112,6 +112,7 @@
   "general.sidebar_title": "Allgemein",
   "general.timeline": "Zeitleiste",
   "general.unread": "Ungelesen",
+  "general.use_default_browser_open_source_content": "Öffne das Original im Standardbrowser",
   "general.voices": "Stimmen",
   "integration.eagle.enable.description": "Zeige den Button „Medien zu Eagle speichern“, wenn verfügbar.",
   "integration.eagle.enable.label": "Aktivieren",

--- a/locales/settings/en.json
+++ b/locales/settings/en.json
@@ -119,6 +119,7 @@
   "general.sidebar_title": "General",
   "general.timeline": "Timeline",
   "general.unread": "Unread",
+  "general.use_default_browser_open_source_content": "Use default browser to open source content",
   "general.voices": "Voices",
   "integration.eagle.enable.description": "Display 'Save media to Eagle' button when available.",
   "integration.eagle.enable.label": "Enable",

--- a/locales/settings/es.json
+++ b/locales/settings/es.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "General",
   "general.timeline": "Línea de tiempo",
   "general.unread": "No leído",
+  "general.use_default_browser_open_source_content": "Usar el navegador predeterminado para abrir el texto original",
   "general.voices": "Voces",
   "integration.eagle.enable.description": "Mostrar el botón 'Guardar medios en Eagle' cuando esté disponible.",
   "integration.eagle.enable.label": "Habilitar",

--- a/locales/settings/fi.json
+++ b/locales/settings/fi.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "Yleiset",
   "general.timeline": "Aikajana",
   "general.unread": "Lukematon",
+  "general.use_default_browser_open_source_content": "Avaa alkuperäinen teksti oletusselaimella",
   "general.voices": "Äänet",
   "integration.eagle.enable.description": "Näytä 'Tallenna media Eagleen' -painike, kun saatavilla.",
   "integration.eagle.enable.label": "Ota käyttöön",

--- a/locales/settings/fr.json
+++ b/locales/settings/fr.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "Général",
   "general.timeline": "Chronologie",
   "general.unread": "Non lu",
+  "general.use_default_browser_open_source_content": "Ouvrir le texte original avec le navigateur par défaut",
   "general.voices": "Voix",
   "integration.eagle.enable.description": "Afficher le bouton 'Enregistrer le média sur Eagle' lorsqu'il est disponible.",
   "integration.eagle.enable.label": "Activer",

--- a/locales/settings/it.json
+++ b/locales/settings/it.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "Generale",
   "general.timeline": "Cronologia",
   "general.unread": "Non letti",
+  "general.use_default_browser_open_source_content": "Apri il documento originale con il browser predefinito",
   "general.voices": "Voci",
   "integration.eagle.enable.description": "Mostra il pulsante 'Salva media su Eagle' quando disponibile.",
   "integration.eagle.enable.label": "Abilita",

--- a/locales/settings/ja.json
+++ b/locales/settings/ja.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "一般",
   "general.timeline": "タイムライン",
   "general.unread": "未読",
+  "general.use_default_browser_open_source_content": "デフォルトのブラウザで原文を開く",
   "general.voices": "音声",
   "integration.eagle.enable.description": "利用可能な場合、'Eagle にメディアを保存' ボタンを表示します。",
   "integration.eagle.enable.label": "有効化",

--- a/locales/settings/ko.json
+++ b/locales/settings/ko.json
@@ -112,6 +112,7 @@
   "general.sidebar_title": "일반",
   "general.timeline": "타임라인",
   "general.unread": "읽지 않음",
+  "general.use_default_browser_open_source_content": "기본 브라우저로 원문 열기",
   "general.voices": "음성",
   "integration.eagle.enable.description": "가능할 때 '미디어를 Eagle 에 저장' 버튼 표시.",
   "integration.eagle.enable.label": "활성화",

--- a/locales/settings/pt.json
+++ b/locales/settings/pt.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "Geral",
   "general.timeline": "Linha do tempo",
   "general.unread": "Não lidos",
+  "general.use_default_browser_open_source_content": "Abrir o texto original com o navegador padrão",
   "general.voices": "Vozes",
   "integration.eagle.enable.description": "Exibir o botão 'Guardar mídia no Eagle' quando disponível.",
   "integration.eagle.enable.label": "Ativar",

--- a/locales/settings/ru.json
+++ b/locales/settings/ru.json
@@ -100,6 +100,7 @@
   "general.sidebar_title": "Общие",
   "general.timeline": "Лента",
   "general.unread": "Непрочитанное",
+  "general.use_default_browser_open_source_content": "Открыть оригинальный текст в браузере по умолчанию",
   "general.voices": "Голоса",
   "integration.eagle.enable.description": "Отображать кнопку 'Сохранить медиа в Eagle', когда доступно.",
   "integration.eagle.enable.label": "Включить",

--- a/locales/settings/tr.json
+++ b/locales/settings/tr.json
@@ -112,6 +112,7 @@
   "general.sidebar_title": "Genel",
   "general.timeline": "Zaman Çizelgesi",
   "general.unread": "Okunmamış",
+  "general.use_default_browser_open_source_content": "",
   "general.voices": "Sesler",
   "integration.eagle.enable.description": "Mevcut olduğunda 'Medyayı Eagle'a kaydet' düğmesini göster.",
   "integration.eagle.enable.label": "Etkinleştir",

--- a/locales/settings/zh-CN.json
+++ b/locales/settings/zh-CN.json
@@ -116,6 +116,7 @@
   "general.sidebar_title": "通用",
   "general.timeline": "时间轴",
   "general.unread": "未读",
+  "general.use_default_browser_open_source_content": "使用默认浏览器打开原文",
   "general.voices": "声音",
   "integration.eagle.enable.description": "显示\"保存到 Eagle\"按钮（如果可用）",
   "integration.eagle.enable.label": "启用",

--- a/locales/settings/zh-HK.json
+++ b/locales/settings/zh-HK.json
@@ -116,6 +116,7 @@
   "general.sidebar_title": "一般",
   "general.timeline": "時間軸",
   "general.unread": "未讀",
+  "general.use_default_browser_open_source_content": "使用默認瀏覽器打開原始內容",
   "general.voices": "語音",
   "integration.eagle.enable.description": "顯示\"將媒體保存到 Eagle\"按鈕（如果可用）。",
   "integration.eagle.enable.label": "啟用",

--- a/locales/settings/zh-TW.json
+++ b/locales/settings/zh-TW.json
@@ -116,6 +116,7 @@
   "general.sidebar_title": "一般",
   "general.timeline": "時間軸",
   "general.unread": "未讀",
+  "general.use_default_browser_open_source_content": "使用預設瀏覽器開啟原始內容",
   "general.voices": "聲音",
   "integration.eagle.enable.description": "顯示「將媒體儲存到 Eagle」按鈕（如果可用）。",
   "integration.eagle.enable.label": "啟用",

--- a/packages/shared/src/interface/settings.ts
+++ b/packages/shared/src/interface/settings.ts
@@ -1,5 +1,6 @@
 export interface GeneralSettings {
   appLaunchOnStartup: boolean
+  useDefaultBrowserOpenSourceContent: boolean
   language: string
   dataPersist: boolean
   sendAnonymousData: boolean


### PR DESCRIPTION
### Description

Support adding an option in the settings page to allow users to choose whether to open the original content through the default browser.

### Linked Issues

### Additional context

Close: https://discord.com/channels/1243823539426033696/1294094455485366312
