### PR TITLE
fix: windows web mark all read ui

### DIFF
--- a/apps/renderer/src/modules/entry-column/components/mark-all-button.tsx
+++ b/apps/renderer/src/modules/entry-column/components/mark-all-button.tsx
@@ -9,7 +9,7 @@ import { useOnClickOutside } from "usehooks-ts"
 import { ActionButton, Button, IconButton } from "~/components/ui/button"
 import { Kbd, KbdCombined } from "~/components/ui/kbd/Kbd"
 import { RootPortal } from "~/components/ui/portal"
-import { ElECTRON_CUSTOM_TITLEBAR_HEIGHT, HotKeyScopeMap } from "~/constants"
+import { ElECTRON_CUSTOM_TITLEBAR_HEIGHT, HotKeyScopeMap, isElectronBuild } from "~/constants"
 import { shortcuts } from "~/constants/shortcuts"
 import { useI18n } from "~/hooks/common"
 import { cn, getOS } from "~/lib/utils"
@@ -51,7 +51,9 @@ export const MarkAllReadWithOverlay = forwardRef<
         <m.div
           ref={setPopoverRef}
           initial={{ y: -70 }}
-          animate={{ y: getOS() === "Windows" ? -ElECTRON_CUSTOM_TITLEBAR_HEIGHT : 0 }}
+          animate={{
+            y: isElectronBuild && getOS() === "Windows" ? -ElECTRON_CUSTOM_TITLEBAR_HEIGHT : 0,
+          }}
           exit={{ y: -70 }}
           transition={{ type: "spring", damping: 20, stiffness: 300 }}
           className="shadow-modal absolute z-50 bg-theme-modal-background-opaque shadow"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

![image](https://github.com/user-attachments/assets/c7a296cf-0874-4557-995c-ff67b928e90f)

The height of the one-click read flag ui on the window web is not correct.

Should be judged to be enabled only in clients on Win `-ElECTRON_CUSTOM_TITLEBAR_HEIGHT`
### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
