### PR TITLE
fix: deeplink adding feed does not work on Windows

### DIFF
--- a/apps/main/src/lib/router.ts
+++ b/apps/main/src/lib/router.ts
@@ -13,6 +13,7 @@ export const handleUrlRouting = (url: string) => {
     const { pathname, searchParams } = new URL(uri, "https://follow.dev")
 
     switch (pathname) {
+      case "/add":
       case "/add/": {
         const mainWindow = getMainWindow()
         if (!mainWindow) {

--- a/apps/main/src/lib/router.ts
+++ b/apps/main/src/lib/router.ts
@@ -13,7 +13,7 @@ export const handleUrlRouting = (url: string) => {
     const { pathname, searchParams } = new URL(uri, "https://follow.dev")
 
     switch (pathname) {
-      case "/add": {
+      case "/add/": {
         const mainWindow = getMainWindow()
         if (!mainWindow) {
           createMainWindow()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

fix: Fixed the issue where the URL parser automatically normalized the path /add to /add/, preventing the add operation from being triggered correctly.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

close #949 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
