### PR TITLE
fix: electron window layout titleSticky ui

### DIFF
--- a/apps/renderer/src/pages/(main)/(layer)/(subview)/layout.tsx
+++ b/apps/renderer/src/pages/(main)/(layer)/(subview)/layout.tsx
@@ -7,8 +7,9 @@ import { getSidebarActiveView, setSidebarActiveView } from "~/atoms/sidebar"
 import { MotionButtonBase } from "~/components/ui/button"
 import { FABContainer, FABPortable } from "~/components/ui/fab"
 import { ScrollArea } from "~/components/ui/scroll-area"
+import { isElectronBuild } from "~/constants"
 import { springScrollTo } from "~/lib/scroller"
-import { cn } from "~/lib/utils"
+import { cn, getOS } from "~/lib/utils"
 
 import { useSubViewTitleValue } from "./hooks"
 
@@ -36,6 +37,10 @@ export function Component() {
   }, [scrollRef])
 
   const { t } = useTranslation()
+
+  // electron window has pt-[calc(var(--fo-window-padding-top)_-10px)]
+  const isElectronWindows = isElectronBuild && getOS() === "Windows"
+
   return (
     <div className="relative flex size-full">
       <div
@@ -43,6 +48,7 @@ export function Component() {
           "absolute inset-x-0 top-0 z-10 p-4",
           "grid grid-cols-[1fr_auto_1fr] items-center gap-4",
           isTitleSticky && "group border-b bg-zinc-50/80 backdrop-blur-xl dark:bg-neutral-900/90",
+          isTitleSticky && isElectronWindows && "-top-5",
         )}
       >
         <MotionButtonBase


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Fix electron window layout titleSticky ui

Before
![image](https://github.com/user-attachments/assets/5aea4357-a242-40ec-98ef-2e2d3ed720bd)

After
![image](https://github.com/user-attachments/assets/053bcdaf-d600-42e5-ada0-65d7e6619744)
![image](https://github.com/user-attachments/assets/e957a6c0-50e2-473f-91c7-965a1dc4b322)

### Linked Issues

https://github.com/RSSNext/Follow/issues/958#issue-2588461487

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
