### PR TITLE
fix: win UI - feed claim modal ui &  header readHistory ui

### DIFF
--- a/apps/renderer/src/modules/claim/hooks.ts
+++ b/apps/renderer/src/modules/claim/hooks.ts
@@ -20,7 +20,6 @@ export const useFeedClaimModal = ({ feedId }: { feedId?: string }) => {
     present({
       title: t("feed_claim_modal.title"),
       content: () => createElement(FeedClaimModalContent, { feedId }),
-      modalClassName: "!h-auto !max-h-screen",
     })
   }, [feedId, present])
 }

--- a/apps/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
+++ b/apps/renderer/src/modules/entry-content/components/EntryReadHistory.tsx
@@ -28,10 +28,15 @@ import { usePresentUserProfileModal } from "../../profile/hooks"
 const getLimit = (width: number): number => {
   const routeParams = getRouteParams()
   // social media view has four extra buttons
-  if (routeParams.view === FeedViewType.SocialMedia) {
-    if (width > 1050) return 15
-    if (width > 750) return 10
-    return 5
+  if (
+    [FeedViewType.SocialMedia, FeedViewType.Pictures, FeedViewType.Videos].includes(
+      routeParams.view,
+    )
+  ) {
+    if (width > 1100) return 15
+    if (width > 950) return 10
+    if (width > 800) return 5
+    return 3
   }
   if (width > 900) return 15
   if (width > 600) return 10


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- Fix the bug that the close button of the authentication feed popup ui on authenticationwin is blocked by the top bar.

Before
![image](https://github.com/user-attachments/assets/de411214-4c23-466b-a5da-2b456950de49)

After
![image](https://github.com/user-attachments/assets/9b8052e6-335c-4424-bf02-55f8916650da)

- Adjust the number of reading history avatars displayed on narrow screens
Before
![image](https://github.com/user-attachments/assets/0d427f21-4276-4699-9acc-1c6fe4e3b383)

After
![image](https://github.com/user-attachments/assets/67b1d3c5-199d-4bf6-81ce-55bbc99049ea)
![image](https://github.com/user-attachments/assets/4524694b-f57f-44c9-89e3-8405a8b2c2bc)
![image](https://github.com/user-attachments/assets/b6df30b9-ad15-403a-b39e-ceca4791a166)

I've adjusted a more comfortable spacing on win here, if it's not right on mac you can look at mac and then return the parameters based on the platform 


### Linked Issues

https://github.com/RSSNext/Follow/issues/958#issue-2588461487

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
