### PR TITLE
fix: optimize the content margin of the Discover Page

### DIFF
--- a/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
+++ b/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
@@ -102,13 +102,15 @@ export function Component() {
             </TabsTrigger>
           ))}
 
-          <Trend className="relative bottom-0 left-1.5" />
+          <Trend className="relative bottom-0 left-1.5 mr-3.5 w-6" />
         </TabsList>
         {currentTabs.map((tab) => (
           <TabsContent key={tab.name} value={tab.value} className="mt-8">
-            {createElement(TabComponent[tab.value] || TabComponent.default, {
-              type: tab.value,
-            })}
+            <div className={tab.value === "inbox" ? "" : "center flex"}>
+              {createElement(TabComponent[tab.value] || TabComponent.default, {
+                type: tab.value,
+              })}
+            </div>
           </TabsContent>
         ))}
       </Tabs>


### PR DESCRIPTION

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. Discover Page' Trending Icon margin right too narrow
2. in Discover Page, content of Search, RSS, RSSHub, RSS3, User, Transform, Import are not centered

**before**
<img width="795" alt="iShot_2024-10-19_10 54 16" src="https://github.com/user-attachments/assets/8840545c-696d-4519-b1fc-090c0dc22fda">

**after**
<img width="745" alt="iShot_2024-10-19_11 00 13" src="https://github.com/user-attachments/assets/67413b37-0843-45d2-9691-f1e8ba5bf3c4">


### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
