### PR TITLE
fix: the search results on the Discover Page are not centered

### DIFF
--- a/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
+++ b/apps/renderer/src/pages/(main)/(layer)/(subview)/discover/index.tsx
@@ -106,7 +106,7 @@ export function Component() {
         </TabsList>
         {currentTabs.map((tab) => (
           <TabsContent key={tab.name} value={tab.value} className="mt-8">
-            <div className={tab.value === "inbox" ? "" : "center flex"}>
+            <div className={tab.value === "inbox" ? "" : "center flex flex-col"}>
               {createElement(TabComponent[tab.value] || TabComponent.default, {
                 type: tab.value,
               })}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

the search results on the Discover Page are not centered

**before**
<img width="1140" alt="iShot_2024-10-20_16 30 19" src="https://github.com/user-attachments/assets/ec7440eb-dd4f-438e-bfe5-54736a746346">

**after**
<img width="923" alt="iShot_2024-10-20_16 31 02" src="https://github.com/user-attachments/assets/b696d553-0724-4ea9-9673-3f68f875d7bd">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
