### PR TITLE
fix: not showing '0' when no followers on the search results card

### DIFF
--- a/apps/renderer/src/modules/discover/form.tsx
+++ b/apps/renderer/src/modules/discover/form.tsx
@@ -342,7 +342,7 @@ const SearchCard: FC<{
             </Button>
             <div className="ml-6 text-zinc-500">
               <span className="font-medium text-zinc-800 dark:text-zinc-200">
-                {item.subscriptionCount}
+                {item.subscriptionCount ?? 0}
               </span>{" "}
               Followers
             </div>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes the issue that '0' is not shown when there's no followers on the search results card.

### Additional context

<img width="564" alt="Screenshot 2024-10-20 at 21 37 42" src="https://github.com/user-attachments/assets/6b8aa045-5cd9-4042-8c0b-0c43168a68fd">
<!-- e.g. is there anything you'd like reviewers to focus on? -->
