### PR TITLE
fix: add height to EntryListHeader for consistent layout

### DIFF
--- a/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -75,7 +75,7 @@ export const EntryListHeader: FC<{
       ref={containerRef}
       className="flex w-full flex-col pl-6 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out"
     >
-      <div className={cn("flex w-full", titleAtBottom ? "justify-end" : "justify-between")}>
+      <div className={cn("flex h-10 w-full", titleAtBottom ? "justify-end" : "justify-between")}>
         {!titleAtBottom && titleInfo}
 
         <div

--- a/locales/app/en.json
+++ b/locales/app/en.json
@@ -240,6 +240,7 @@
   "search.placeholder": "Search...",
   "search.result_count_local_mode": "(Local mode)",
   "search.tooltip.local_search": "This search covers locally available data. Try a Refetch to include the latest data.",
+  "shortcuts.guide.title": "Shortcuts Guide",
   "sidebar.add_more_feeds": "Add more feeds",
   "sidebar.category_remove_dialog.cancel": "Cancel",
   "sidebar.category_remove_dialog.continue": "Continue",


### PR DESCRIPTION
before:
<img width="528" alt="image" src="https://github.com/user-attachments/assets/b407255b-e6ba-4efa-ab65-a142f4b86aa9">


after:

<img width="457" alt="image" src="https://github.com/user-attachments/assets/d2bb49b1-2f49-4e54-b099-dba82c24ef30">
