### PR TITLE
fix: margin between the top bar and the content

### DIFF
--- a/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -73,9 +73,12 @@ export const EntryListHeader: FC<{
   return (
     <div
       ref={containerRef}
-      className="flex w-full flex-col pl-6 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out"
+      className={cn(
+        "flex w-full flex-col pl-6 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out",
+        view !== FeedViewType.Articles && view !== FeedViewType.Pictures && "mb-2",
+      )}
     >
-      <div className={cn("flex h-10 w-full", titleAtBottom ? "justify-end" : "justify-between")}>
+      <div className={cn("flex w-full", titleAtBottom ? "justify-end" : "justify-between")}>
         {!titleAtBottom && titleInfo}
 
         <div


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This issue https://github.com/RSSNext/Follow/issues/1049 mentions the problem of the top bar being obscured. 
This PR https://github.com/RSSNext/Follow/pull/1051 addresses that issue.
But I noticed there are still some problems on the Video page.
The margins are too narrow. 
<img width="444" alt="iShot_2024-10-22_10 50 22" src="https://github.com/user-attachments/assets/00f65ef9-602b-4bd7-9c1b-a8eb12f28724">

Here's how it looked before.
<img width="338" alt="iShot_2024-10-22_10 50 47" src="https://github.com/user-attachments/assets/f55e9cf1-b3ac-4612-afef-72394e00e6d4">

I tried to find the cause of the above issue. I checked the commit history, and in this commit https://github.com/RSSNext/Follow/commit/847c317bb4fe4258b7eed240e5e6422bf273838d#diff-8edd1371c19527656614803122cca80cb2fde924536821a4f868bbf727a55157, the "mb-2" style was removed, which led to the issue with the top bar being obscured. I think the removal of "mb-2" here,  is to handle the situation where there need a TimelineTabs component.

I think the approach to solving this issue should be to determine whether "mb-2" is needed based on the type of displayed content. 
So I submitted this PR.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
