### PR TITLE
fix: allow activation modal to be closable

### DIFF
--- a/apps/renderer/src/lib/api-fetch.ts
+++ b/apps/renderer/src/lib/api-fetch.ts
@@ -63,6 +63,7 @@ export const apiFetch = ofetch.create({
               },
             }),
             {
+              closeButton: true,
               duration: 10e4,
             },
           )


### PR DESCRIPTION
This PR introduces a feature that allows the activation modal to be closed by the user.

The `canClose` property has been added to enhance user experience by providing more control over the modal's visibility.

Before

![image](https://github.com/user-attachments/assets/dcc7cd3e-ea5c-41de-97fd-1e4e01aeae6c)

After

<img width="537" alt="Screenshot 2024-10-23 at 14 23 51" src="https://github.com/user-attachments/assets/e1818888-7664-4730-a8b7-85fbcd3a5efb">

