### PR TITLE
fix: Wrong initial position of tab animation

### DIFF
--- a/apps/renderer/src/components/ui/tabs.tsx
+++ b/apps/renderer/src/components/ui/tabs.tsx
@@ -113,6 +113,9 @@ const TabsTrigger = React.forwardRef<HTMLDivElement, TabsTriggerProps>(
         {isSelect && (
           <m.span
             layoutId={layoutId}
+            style={{
+              originY: '0px',
+            }}
             className={cn(
               "absolute",
               variant === "rounded"

--- a/apps/renderer/src/components/ui/tabs.tsx
+++ b/apps/renderer/src/components/ui/tabs.tsx
@@ -114,7 +114,7 @@ const TabsTrigger = React.forwardRef<HTMLDivElement, TabsTriggerProps>(
           <m.span
             layoutId={layoutId}
             style={{
-              originY: '0px',
+              originY: "0px",
             }}
             className={cn(
               "absolute",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

https://github.com/user-attachments/assets/5887f22c-e0f4-4d0f-b465-7fbebfe71dae

Currently, under the power page, the tab indicator animation at the bottom will be shifted from its initial position after the page is scrolled, this can be avoided by setting style={{originY: ‘0px’,}}


### Linked Issues

### Additional context

This is solved by setting style={{originY: ‘0px’,}}

https://github.com/user-attachments/assets/1b95c099-54c5-4496-aa48-dda78804eb5b

