### PR TITLE
fix: margin condition in EntryListHeader

### DIFF
--- a/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -75,7 +75,7 @@ export const EntryListHeader: FC<{
       ref={containerRef}
       className={cn(
         "flex w-full flex-col pl-6 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out",
-        view !== FeedViewType.Articles && view !== FeedViewType.Pictures && "mb-2",
+        view !== FeedViewType.Pictures && "mb-2",
       )}
     >
       <div className={cn("flex w-full", titleAtBottom ? "justify-end" : "justify-between")}>


### PR DESCRIPTION
Related: #1054

It seems only `Pictures` doesn't need add margin style.

| before | after |
| ------- | ------ |
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/981b692a-f0b4-45a8-bbec-e8cf82b2e6e9"> | <img width="470" alt="image" src="https://github.com/user-attachments/assets/e1438854-56f7-4c7d-9dfa-6c407f8c0e1e"> |
