### PR TITLE
fix: EntryListHeader' margin in Pictures View

### DIFF
--- a/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -69,13 +69,16 @@ export const EntryListHeader: FC<{
   const isList = !!listId
 
   const containerRef = React.useRef<HTMLDivElement>(null)
+  const timelineTabsRef = React.useRef<HTMLDivElement>(null)
 
   return (
     <div
       ref={containerRef}
       className={cn(
         "flex w-full flex-col pl-6 pr-4 pt-2.5 transition-[padding] duration-300 ease-in-out",
-        view !== FeedViewType.Pictures && "mb-2",
+        timelineTabsRef.current
+          ? view !== FeedViewType.Articles && view !== FeedViewType.Pictures && "mb-2"
+          : "mb-2",
       )}
     >
       <div className={cn("flex w-full", titleAtBottom ? "justify-end" : "justify-between")}>
@@ -156,7 +159,7 @@ export const EntryListHeader: FC<{
         </div>
       </div>
       {titleAtBottom && titleInfo}
-      <TimelineTabs />
+      <TimelineTabs ref={timelineTabsRef} />
     </div>
   )
 }

--- a/apps/renderer/src/modules/entry-column/layouts/TimelineTabs.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/TimelineTabs.tsx
@@ -1,11 +1,12 @@
 import { Tabs, TabsList, TabsTrigger } from "@follow/components/ui/tabs/index.jsx"
+import { forwardRef } from "react"
 
 import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
 import { useRouteParams } from "~/hooks/biz/useRouteParams"
 import { InboxItem, ListItem } from "~/modules/feed-column/item"
 import { useSubscriptionStore } from "~/store/subscription"
 
-export const TimelineTabs = () => {
+export const TimelineTabs = forwardRef<HTMLDivElement>((_props, ref) => {
   const routerParams = useRouteParams()
   const { view, listId, inboxId } = routerParams
 
@@ -29,6 +30,7 @@ export const TimelineTabs = () => {
 
   return (
     <Tabs
+      ref={ref}
       className="-ml-3 -mr-4 mt-1 flex overflow-x-auto scrollbar-none"
       value={timeline}
       onValueChange={(val) => {
@@ -68,4 +70,4 @@ export const TimelineTabs = () => {
       </TabsList>
     </Tabs>
   )
-}
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Related: https://github.com/RSSNext/Follow/pull/1103
There are still some questions here
When there is no `TimelineTabs` component, there are some margin issues in the `Pictures Page`
<img width="925" alt="iShot_2024-10-24_14 07 29" src="https://github.com/user-attachments/assets/1760f65a-9371-4ac1-8eb8-fb5ae445dbf3">

In my previous PR https://github.com/RSSNext/Follow/pull/1054, I added `mb-2 style` when there is not the `Articles Page` and `Pictures Page` because these two pages have `TimelineTabs` component. At that time, there are some issues with my modifications, I did not consider the situation where `TimelineTabs` component were not available (this component would not display when user do not have lists and inbox data)
So my idea is control whether `mb-2 style` is required by determining whether the `TimelineTabs` component is null
So I submitted this PR.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
