### PR TITLE
fix: optimize the appearing horizontal scroll bar.

### DIFF
--- a/apps/renderer/src/modules/ai/ai-daily/daily.tsx
+++ b/apps/renderer/src/modules/ai/ai-daily/daily.tsx
@@ -365,6 +365,7 @@ const EntryToastPreview = ({ entryId }: { entryId: string }) => {
                 "rounded-xl p-3 align-middle text-[15px]",
                 "rounded-tl-none bg-zinc-600/5 dark:bg-zinc-500/20",
                 "mt-1 -translate-x-3",
+                "break-words",
               )}
             >
               {entry.entries.description}


### PR DESCRIPTION
Daily summary feature, when long address information appears, an unfriendly horizontal scroll bar will appear. Optimize it.

<img width="846" alt="image" src="https://github.com/user-attachments/assets/688adffe-3689-42a9-a9b8-7907b63bc1ca">
