### PR TITLE
fix: fix toast wrong tip amount

### DIFF
--- a/apps/renderer/src/modules/wallet/tip-modal.tsx
+++ b/apps/renderer/src/modules/wallet/tip-modal.tsx
@@ -145,6 +145,7 @@ const TipModalContent_: FC<{
         <RadioGroup value={amount.toString()} onValueChange={(value) => setAmount(Number(value))}>
           <div className="grid grid-cols-2 gap-2">
             <RadioCard
+              disabled={tipMutation.isPending}
               wrapperClassName="justify-center"
               label={
                 <span className="flex items-center gap-1">
@@ -154,6 +155,7 @@ const TipModalContent_: FC<{
               value="10"
             />
             <RadioCard
+              disabled={tipMutation.isPending}
               wrapperClassName="justify-center group"
               label={
                 <span className="flex items-center gap-1">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
when user change the tip amount after user click "tip now". the toast is last select not correct. so I disable the amount select after click "tip now"


### Linked Issues

### Additional context

user select amount 10 and click tip now and select amount 20. the toast is 20 not 10

<!-- e.g. is there anything you'd like reviewers to focus on? -->
