### PR TITLE
fix(app): throw error popup when close window

### DIFF
--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -123,7 +123,7 @@ function bootstrap() {
   app.on("before-quit", () => {
     // store window pos when before app quit
     const window = getMainWindow()
-    if (!window) return
+    if (!window || window.isDestroyed()) return
     const bounds = window.getBounds()
 
     store.set(windowStateStoreKey, {


### PR DESCRIPTION
### Description

Once the window is destroyed, none of the window's methods can be used (except for `destroy` and `isDestroyed`).


### Linked Issues

Fix: #1127 #1092

### Additional context

The reason that destroy can be called multiple times is that Electron performs a check: https://github.com/electron/electron/blob/57920e7747f09627f99ed5c27457339aa7c3fe57/shell/common/gin_helper/destroyable.cc#L28

The ability to call isDestroyed is because no window methods are used during the implementation process: https://github.com/electron/electron/blob/57920e7747f09627f99ed5c27457339aa7c3fe57/shell/common/gin_helper/destroyable.cc#L48-L49
