### PR TITLE
feat: add follow user button in profile modal

### DIFF
--- a/apps/renderer/src/modules/profile/user-profile-modal.tsx
+++ b/apps/renderer/src/modules/profile/user-profile-modal.tsx
@@ -60,15 +60,18 @@ export const UserProfileModalContent: FC<{
         avatar: user.data.image,
         name: user.data.name,
         handle: user.data.handle,
+        id: user.data.id,
       }
     : storeUser
       ? {
           avatar: storeUser.image,
           name: storeUser.name,
           handle: storeUser.handle,
+          id: storeUser.id,
         }
       : null
 
+  const follow = useFollow()
   const subscriptions = useUserSubscriptionsQuery(user.data?.id)
   const modal = useCurrentModal()
   const controller = useAnimationControls()
@@ -270,16 +273,36 @@ export const UserProfileModalContent: FC<{
                 >
                   <m.h1 layout>{userInfo.name}</m.h1>
                 </m.div>
-
                 <m.div
                   className={cn(
-                    "mb-0 text-sm text-zinc-500",
+                    "mb-0.5 text-xs text-zinc-500",
+                    userInfo?.id ? "visible" : "hidden select-none",
+                  )}
+                  layout
+                >
+                  uid: {userInfo.id}
+                </m.div>
+                <m.div
+                  className={cn(
+                    "text-sm text-zinc-500",
                     userInfo.handle ? "visible" : "hidden select-none",
                   )}
                   layout
                 >
                   @{userInfo.handle}
                 </m.div>
+                <Button
+                  buttonClassName="mt-2"
+                  onClick={() => {
+                    follow({
+                      url: `rsshub://follow/profile/${userInfo.id}`,
+                      isList: false,
+                    })
+                  }}
+                >
+                  <FollowIcon className="mr-1 size-3" />
+                  {APP_NAME}
+                </Button>
               </m.div>
             </div>
             <ScrollArea.ScrollArea

--- a/apps/renderer/src/modules/profile/user-profile-modal.tsx
+++ b/apps/renderer/src/modules/profile/user-profile-modal.tsx
@@ -275,15 +275,6 @@ export const UserProfileModalContent: FC<{
                 </m.div>
                 <m.div
                   className={cn(
-                    "mb-0.5 text-xs text-zinc-500",
-                    userInfo?.id ? "visible" : "hidden select-none",
-                  )}
-                  layout
-                >
-                  uid: {userInfo.id}
-                </m.div>
-                <m.div
-                  className={cn(
                     "text-sm text-zinc-500",
                     userInfo.handle ? "visible" : "hidden select-none",
                   )}
@@ -301,7 +292,7 @@ export const UserProfileModalContent: FC<{
                   }}
                 >
                   <FollowIcon className="mr-1 size-3" />
-                  {APP_NAME}
+                  {t("feed_form.follow")}
                 </Button>
               </m.div>
             </div>

--- a/apps/server/client/pages/share/users/[id]/index.tsx
+++ b/apps/server/client/pages/share/users/[id]/index.tsx
@@ -46,9 +46,8 @@ export const Component = () => {
               <h1>{user.data?.name}</h1>
             </div>
             {user.data?.handle && (
-              <div className="mb-1 text-sm text-zinc-500">@{user.data.handle}</div>
+              <div className="mb-2 text-sm text-zinc-500">@{user.data.handle}</div>
             )}
-            {user.data?.id && <div className="mb-2 text-sm text-zinc-500">{user.data.id}</div>}
             {user.data?.id && (
               <Button
                 onClick={() => {

--- a/apps/server/client/pages/share/users/[id]/index.tsx
+++ b/apps/server/client/pages/share/users/[id]/index.tsx
@@ -58,7 +58,7 @@ export const Component = () => {
                 }}
               >
                 <FollowIcon className="mr-1 size-3" />
-                {APP_NAME}
+                {t("words.follow")}
               </Button>
             )}
           </div>

--- a/apps/server/client/pages/share/users/[id]/index.tsx
+++ b/apps/server/client/pages/share/users/[id]/index.tsx
@@ -27,6 +27,7 @@ export const Component = () => {
   const isMe = user.data?.id === me?.id
 
   const { t } = useTranslation("common")
+
   return (
     <MainContainer className="items-center">
       {user.isLoading ? (
@@ -40,12 +41,25 @@ export const Component = () => {
             />
             <AvatarFallback>{user.data?.name?.slice(0, 2)}</AvatarFallback>
           </Avatar>
-          <div className="flex flex-col items-center">
+          <div className="mb-8 flex flex-col items-center">
             <div className="mb-2 mt-4 flex items-center text-2xl font-bold">
               <h1>{user.data?.name}</h1>
             </div>
             {user.data?.handle && (
-              <div className="mb-8 text-sm text-zinc-500">@{user.data.handle}</div>
+              <div className="mb-1 text-sm text-zinc-500">@{user.data.handle}</div>
+            )}
+            {user.data?.id && <div className="mb-2 text-sm text-zinc-500">{user.data.id}</div>}
+            {user.data?.id && (
+              <Button
+                onClick={() => {
+                  openInFollowApp(`add?url=rsshub://follow/profile/${user.data?.id}`, () => {
+                    window.location.href = `rsshub://follow/profile/${user.data?.id}`
+                  })
+                }}
+              >
+                <FollowIcon className="mr-1 size-3" />
+                {APP_NAME}
+              </Button>
             )}
           </div>
           <div

--- a/locales/common/en.json
+++ b/locales/common/en.json
@@ -21,6 +21,7 @@
   "words.edit": "Edit",
   "words.entry": "Entry",
   "words.expand": "Expand",
+  "words.follow": "Follow",
   "words.id": "ID",
   "words.items_one": "Item",
   "words.items_other": "Items",


### PR DESCRIPTION
### Description
Adding a follow user button and user ID in profile model and share page.

I see that there are routes for follow on RSSHub to follow [follow-user-subscriptions](https://docs.rsshub.app/routes/social-media#user-subscriptions) based on this.

![image](https://github.com/user-attachments/assets/1f5fb2b4-ce62-4f6e-bf1b-851081a20393)

![image](https://github.com/user-attachments/assets/6ad6dbf4-44c7-4cca-a177-709abaa15438)

The profile modal was tested on my Win client and web with no problem, the profile page of the share page  was not tested because I couldn't run the server (eg: https://app.follow.is/share/users/hyoban), it needs to be reviewed.

![image](https://github.com/user-attachments/assets/ad8b1239-a71b-434d-ada4-315e78e8e1dc)

### Linked Issues

### Additional context

https://github.com/RSSNext/Follow/issues/480

<!-- e.g. is there anything you'd like reviewers to focus on? -->
