### PR TITLE
refactor: display the formatted ai daily content

### DIFF
--- a/apps/renderer/src/modules/ai/ai-daily/daily.tsx
+++ b/apps/renderer/src/modules/ai/ai-daily/daily.tsx
@@ -367,7 +367,7 @@ const EntryToastPreview = ({ entryId }: { entryId: string }) => {
                 "break-words",
               )}
             >
-              {entry.entries.description}
+              <div dangerouslySetInnerHTML={{ __html: entry.entries.content || "" }} />
 
               {!!entry.entries.media?.length && (
                 <div className="mt-1 flex w-full gap-2 overflow-x-auto">


### PR DESCRIPTION
AI daily report displays formatted information, looking better

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/397a91cb-3140-4fdb-988d-26d696ee08c1">
