### PR TITLE
fix: modal close button overlaps the select content

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/components.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/components.tsx
@@ -10,7 +10,7 @@ export const ModalClose = () => {
   return (
     <MotionButtonBase
       aria-label={t("close")}
-      className="absolute right-6 top-6 z-[99] flex size-8 items-center justify-center rounded-md duration-200 hover:bg-theme-button-hover"
+      className="absolute right-6 top-6 flex size-8 items-center justify-center rounded-md duration-200 hover:bg-theme-button-hover"
       onClick={dismiss}
     >
       <i className="i-mgc-close-cute-re block" />


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes the issue that the close button of the settings modal overlaps the language select content.

### Linked Issues

### Additional context

A screenshot of this issue (web app):

<img width="640" alt="Screenshot 2024-10-27 at 00 20 27" src="https://github.com/user-attachments/assets/ac34441c-a25a-4568-866b-8b02dd2c8c4f">