### PR TITLE
refactor: add UserGallery and integrate into SupportCreator

### DIFF
--- a/apps/renderer/src/modules/boost/boosting-contributors.tsx
+++ b/apps/renderer/src/modules/boost/boosting-contributors.tsx
@@ -5,6 +5,8 @@ import { replaceImgUrlIfNeed } from "~/lib/img-proxy"
 import { useFeedBoostersQuery } from "~/modules/boost/query"
 
 import { usePresentUserProfileModal } from "../profile/hooks"
+import { UserGallery } from "../user/UserGallery"
+import type { User } from "../user/utils"
 
 export const BoostingContributors = ({ feedId }: { feedId: string }) => {
   const { data: boosters, isLoading } = useFeedBoostersQuery(feedId)
@@ -21,27 +23,34 @@ export const BoostingContributors = ({ feedId }: { feedId: string }) => {
     >
       <h2 className="mb-4 text-2xl font-bold">Boosting Contributors</h2>
       <ul className="space-y-4">
-        {boosters
-          .map((user) => (
-            <li
-              key={user.id}
-              role="button"
-              className="flex items-center space-x-4"
-              onClick={() => presentUserProfile(user.id)}
-            >
-              <Avatar className="block aspect-square size-10 overflow-hidden rounded-full border border-border ring-1 ring-background">
-                <AvatarImage src={replaceImgUrlIfNeed(user?.image || undefined)} />
-                <AvatarFallback>{user.name?.slice(0, 2)}</AvatarFallback>
-              </Avatar>
-              <div>
-                <div className="font-semibold">{user.name || user.handle}</div>
-                {user.handle && <div className="text-xs text-gray-500">@{user.handle}</div>}
-              </div>
-            </li>
+        {boosters.length < 8 ? (
+          boosters.map((user) => (
+            <UserListItem key={user.id} user={user} onClick={presentUserProfile} />
           ))
-          // TODO use grid layout when there are many boosters
-          .slice(0, 10)}
+        ) : (
+          <UserGallery users={boosters} />
+        )}
       </ul>
     </m.div>
+  )
+}
+
+const UserListItem = ({ user, onClick }: { user: User; onClick: (userId: string) => void }) => {
+  return (
+    <li
+      key={user.id}
+      role="button"
+      className="flex items-center space-x-4"
+      onClick={() => onClick(user.id)}
+    >
+      <Avatar className="block aspect-square size-10 overflow-hidden rounded-full border border-border ring-1 ring-background">
+        <AvatarImage src={replaceImgUrlIfNeed(user?.image || undefined)} />
+        <AvatarFallback>{user.name?.slice(0, 2)}</AvatarFallback>
+      </Avatar>
+      <div>
+        <div className="font-semibold">{user.name || user.handle}</div>
+        {user.handle && <div className="text-xs text-gray-500">@{user.handle}</div>}
+      </div>
+    </li>
   )
 }

--- a/apps/renderer/src/modules/user/UserGallery.tsx
+++ b/apps/renderer/src/modules/user/UserGallery.tsx
@@ -8,7 +8,7 @@ interface UserGalleryProps {
   limit?: number
 }
 
-export const UserGallery = ({ users, limit = 16 }: UserGalleryProps) => {
+export const UserGallery = ({ users, limit = 18 }: UserGalleryProps) => {
   const displayedUsers = users.slice(0, limit)
 
   return (

--- a/apps/renderer/src/modules/user/UserGallery.tsx
+++ b/apps/renderer/src/modules/user/UserGallery.tsx
@@ -1,0 +1,29 @@
+import { UserAvatar } from "~/modules/user/UserAvatar"
+
+import type { User } from "./utils"
+
+interface UserGalleryProps {
+  users: User[]
+  dedupe?: boolean
+  limit?: number
+}
+
+export const UserGallery = ({ users, limit = 16 }: UserGalleryProps) => {
+  const displayedUsers = users.slice(0, limit)
+
+  return (
+    <div className="flex w-fit max-w-80 flex-wrap gap-4">
+      {displayedUsers.map((user) => (
+        <div key={user.id} className="size-8">
+          <UserAvatar
+            className="h-auto p-0"
+            avatarClassName="size-8"
+            userId={user?.id}
+            enableModal={true}
+            hideName={true}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/renderer/src/modules/user/utils.ts
+++ b/apps/renderer/src/modules/user/utils.ts
@@ -1,0 +1,16 @@
+export interface User {
+  name: string | null
+  id: string
+  emailVerified: string | null
+  image: string | null
+  handle: string | null
+  createdAt: string
+}
+
+export const deduplicateUsers = (users: User[]): User[] => {
+  const userMap = new Map<string, User>()
+  users.forEach((user) => {
+    userMap.set(user.id, user)
+  })
+  return Array.from(userMap.values())
+}

--- a/apps/renderer/src/store/feed/store.ts
+++ b/apps/renderer/src/store/feed/store.ts
@@ -54,12 +54,13 @@ class FeedActions {
             }
 
             // Not all API return these fields, so merging is needed here.
-            const optionalFields = ["owner", "tipUsers"] as const
-            optionalFields.forEach((field) => {
-              if (state.feeds[feed.id!]?.[field] && !(field in feed)) {
-                ;(feed as any)[field] = { ...state.feeds[feed.id!]?.[field] }
-              }
-            })
+            const targetFeed = state.feeds[feed.id]
+            if (targetFeed?.owner) {
+              feed.owner = { ...targetFeed.owner }
+            }
+            if (targetFeed && "tipUsers" in targetFeed && targetFeed.tipUsers) {
+              feed.tipUsers = [...targetFeed.tipUsers]
+            }
 
             state.feeds[feed.id] = omit(feed, "feeds") as FeedOrListModel
           } else {


### PR DESCRIPTION
Introduce the UserGallery component to display deduplicated supporters and boosting contributors.

Refactor SupportCreator to utilize the new UserGallery for improved user presentation.

<img width="438" alt="Screenshot 2024-10-27 at 03 38 59" src="https://github.com/user-attachments/assets/5512668e-880a-467d-8744-c9976899d83e">
