### PR TITLE
fix: detecting windows11

### DIFF
--- a/apps/main/preload/index.ts
+++ b/apps/main/preload/index.ts
@@ -9,7 +9,22 @@ export const isMacOS = platform === "darwin"
 export const isWindows = platform === "win32"
 
 export const isLinux = platform === "linux"
-export const isWindows11 = isWindows && os.version().startsWith("Windows 11")
+
+/**
+ * @see https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
+ * Windows 11 buildNumber starts from 22000.
+ */
+const detectingWindows11 = () => {
+  if (!isWindows) return false
+
+  const release = os.release()
+  const majorVersion = Number.parseInt(release.split(".")[0])
+  const buildNumber = Number.parseInt(release.split(".")[2])
+
+  return majorVersion === 10 && buildNumber >= 22000
+}
+
+export const isWindows11 = detectingWindows11()
 
 // Custom APIs for renderer
 const api = {

--- a/apps/main/src/env.ts
+++ b/apps/main/src/env.ts
@@ -11,4 +11,19 @@ export const isMacOS = platform === "darwin"
 export const isWindows = platform === "win32"
 
 export const isLinux = platform === "linux"
-export const isWindows11 = isWindows && os.version().startsWith("Windows 11")
+
+/**
+ * @see https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
+ * Windows 11 buildNumber starts from 22000.
+ */
+const detectingWindows11 = () => {
+  if (!isWindows) return false
+
+  const release = os.release()
+  const majorVersion = Number.parseInt(release.split(".")[0])
+  const buildNumber = Number.parseInt(release.split(".")[2])
+
+  return majorVersion === 10 && buildNumber >= 22000
+}
+
+export const isWindows11 = detectingWindows11()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

There is a problem with the current [isWindows11](https://github.com/RSSNext/Follow/blob/dev/apps/main/preload/index.ts#L12) detecting because `os.version()` only returns the version number and does not return the `"Windows 11"` identification before the version number.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
