### PR TITLE
fix: disable `pointerDownOutside` trigger `onDismiss`

### DIFF
--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -94,15 +94,6 @@ export const ModalInternal = memo(
       onPropsClose?.(false)
     })
 
-    const onClose = useCallback(
-      (open: boolean): void => {
-        if (!open) {
-          close()
-        }
-      },
-      [close],
-    )
-
     const opaque = useUISettingKey("modalOpaque")
     const modalSettingOverlay = useUISettingKey("modalOverlay")
 
@@ -232,7 +223,7 @@ export const ModalInternal = memo(
     if (CustomModalComponent) {
       return (
         <Wrapper>
-          <Dialog.Root open onOpenChange={onClose} modal={modal}>
+          <Dialog.Root open modal={modal}>
             <Dialog.Portal>
               {Overlay}
               <Dialog.DialogTitle className="sr-only">{title}</Dialog.DialogTitle>
@@ -278,7 +269,7 @@ export const ModalInternal = memo(
 
     return (
       <Wrapper>
-        <Dialog.Root modal={modal} open onOpenChange={onClose}>
+        <Dialog.Root modal={modal} open>
           <Dialog.Portal>
             {Overlay}
             <Dialog.Content asChild aria-describedby={undefined} onOpenAutoFocus={openAutoFocus}>

--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -236,7 +236,12 @@ export const ModalInternal = memo(
             <Dialog.Portal>
               {Overlay}
               <Dialog.DialogTitle className="sr-only">{title}</Dialog.DialogTitle>
-              <Dialog.Content asChild aria-describedby={undefined} onOpenAutoFocus={openAutoFocus}>
+              <Dialog.Content
+                asChild
+                aria-describedby={undefined}
+                onPointerDownOutside={(event) => event.preventDefault()}
+                onOpenAutoFocus={openAutoFocus}
+              >
                 <div
                   ref={setEdgeElementRef}
                   className={cn(
@@ -281,7 +286,12 @@ export const ModalInternal = memo(
         <Dialog.Root modal={modal} open onOpenChange={onClose}>
           <Dialog.Portal>
             {Overlay}
-            <Dialog.Content asChild aria-describedby={undefined} onOpenAutoFocus={openAutoFocus}>
+            <Dialog.Content
+              asChild
+              aria-describedby={undefined}
+              onPointerDownOutside={(event) => event.preventDefault()}
+              onOpenAutoFocus={openAutoFocus}
+            >
               <div
                 ref={setEdgeElementRef}
                 className={cn(

--- a/apps/renderer/src/components/ui/modal/stacked/modal.tsx
+++ b/apps/renderer/src/components/ui/modal/stacked/modal.tsx
@@ -94,6 +94,15 @@ export const ModalInternal = memo(
       onPropsClose?.(false)
     })
 
+    const onClose = useCallback(
+      (open: boolean): void => {
+        if (!open) {
+          close()
+        }
+      },
+      [close],
+    )
+
     const opaque = useUISettingKey("modalOpaque")
     const modalSettingOverlay = useUISettingKey("modalOverlay")
 
@@ -223,7 +232,7 @@ export const ModalInternal = memo(
     if (CustomModalComponent) {
       return (
         <Wrapper>
-          <Dialog.Root open modal={modal}>
+          <Dialog.Root open onOpenChange={onClose} modal={modal}>
             <Dialog.Portal>
               {Overlay}
               <Dialog.DialogTitle className="sr-only">{title}</Dialog.DialogTitle>
@@ -269,7 +278,7 @@ export const ModalInternal = memo(
 
     return (
       <Wrapper>
-        <Dialog.Root modal={modal} open>
+        <Dialog.Root modal={modal} open onOpenChange={onClose}>
           <Dialog.Portal>
             {Overlay}
             <Dialog.Content asChild aria-describedby={undefined} onOpenAutoFocus={openAutoFocus}>


### PR DESCRIPTION
### Description

fix electron app
> I don't know why it can't be reproduced stably
- accidentally called `onClose` once more when opening the modal.
- `onClose` multiple called

https://github.com/user-attachments/assets/c3b9051f-86e7-4129-80ce-f57b67fea929

### Linked Issues

### Additional context




<!-- e.g. is there anything you'd like reviewers to focus on? -->
