### PR TITLE
fix: remove gcore icon

### DIFF
--- a/packages/utils/src/link-parser.ts
+++ b/packages/utils/src/link-parser.ts
@@ -47,12 +47,6 @@ export const isXUrl = defineLinkParser({
   icon: "i-mgc-social-x-cute-li",
 })
 
-export const isGCoreUrl = defineLinkParser({
-  name: "gcore",
-  validator: (url) => url.hostname.includes("gcores.com"),
-  icon: "i-simple-icons-gcore text-[#f83055]",
-})
-
 export const isV2exUrl = defineLinkParser({
   name: "v2ex",
   validator: (url) => url.hostname.includes("v2ex.com"),


### PR DESCRIPTION
### Description
Fixed the incorrect icon reference issue. The previous code mistakenly used the [Gcore](https://gcore.com/) icon as the [Gcores](https://www.gcores.com/) icon, but these are two different websites. 

This PR corrects that mistake.

### Linked Issues
None

### Additional context
| Before   | After     |
| --------- | -------- |
|![before](https://github.com/user-attachments/assets/c314613c-1e92-47a2-9771-86226e21af22)| ![after](https://github.com/user-attachments/assets/4096fad5-ca79-4598-8a44-0c37fc892b1e)|
