### PR TITLE
fix: html table to markdown error

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -64,6 +64,7 @@
     "lethargy": "1.0.9",
     "lodash-es": "4.17.21",
     "masonic": "4.0.1",
+    "mdast-util-gfm-table": "^2.0.0",
     "mdast-util-to-markdown": "^2.1.0",
     "nanoid": "5.0.7",
     "ofetch": "1.4.1",

--- a/apps/renderer/src/lib/parse-html.ts
+++ b/apps/renderer/src/lib/parse-html.ts
@@ -6,6 +6,7 @@ import type { Components } from "hast-util-to-jsx-runtime"
 import { toJsxRuntime } from "hast-util-to-jsx-runtime"
 import { toMdast } from "hast-util-to-mdast"
 import { toText } from "hast-util-to-text"
+import { gfmTableToMarkdown } from "mdast-util-gfm-table"
 import { toMarkdown } from "mdast-util-to-markdown"
 import { createElement } from "react"
 import { Fragment, jsx, jsxs } from "react/jsx-runtime"
@@ -237,7 +238,7 @@ export const parseHtml = (
         },
       }),
     toText: () => toText(hastTree),
-    toMarkdown: () => toMarkdown(toMdast(hastTree)),
+    toMarkdown: () => toMarkdown(toMdast(hastTree), { extensions: [gfmTableToMarkdown()] }),
   }
 }
 

--- a/locales/app/ja.json
+++ b/locales/app/ja.json
@@ -14,7 +14,6 @@
   "achievement.list_subscribe_500": "500 リスト購読者",
   "achievement.list_subscribe_500_description": "あなたが作成したリストの購読者数が 500 人を超えました",
   "achievement.list_subscribe_50_description": "あなたが作成したリストの購読者数が 50 人を超えました",
-  "achievement.mint_more_power": "ハードコア プレイヤーになるとさらなる報酬を得られます <power />",
   "achievement.product_hunt_vote": "Product Hunt 投票者",
   "achievement.product_hunt_vote_description": "あなたは Product Hunt での Follow サポーターです",
   "activation.activate": "有効化",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,6 +474,9 @@ importers:
       masonic:
         specifier: 4.0.1
         version: 4.0.1(react@18.3.1)
+      mdast-util-gfm-table:
+        specifier: ^2.0.0
+        version: 2.0.0
       mdast-util-to-markdown:
         specifier: ^2.1.0
         version: 2.1.0


### PR DESCRIPTION
### Description

Added the mdast-util-gfm-table extension to fix a serialization error encountered when converting HTML containing table nodes to Markdown.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
