### PR TITLE
refactor: context menu functionality

### DIFF
--- a/apps/renderer/src/atoms/context-menu.ts
+++ b/apps/renderer/src/atoms/context-menu.ts
@@ -1,0 +1,178 @@
+import { IN_ELECTRON } from "@follow/shared/constants"
+import { getOS } from "@follow/utils/utils"
+import { atom } from "jotai"
+import { useCallback } from "react"
+
+import { tipcClient } from "~/lib/client"
+import { createAtomHooks } from "~/lib/jotai"
+import type { ElectronMenuItem } from "~/lib/native-menu"
+import { showElectronContextMenu } from "~/lib/native-menu"
+
+// Atom
+
+type ContextMenuState =
+  | { open: false }
+  | {
+      open: true
+      position: { x: number; y: number }
+      menuItems: NativeMenuItem[]
+      // Just for abort callback
+      // Also can be optimized by using the `atomWithListeners`
+      abortController: AbortController
+    }
+
+export const [contextMenuAtom, useContextMenuState, useContextMenuValue, useSetContextMenu] =
+  createAtomHooks(atom<ContextMenuState>({ open: false }))
+
+const useShowWebContextMenu = () => {
+  const setContextMenu = useSetContextMenu()
+
+  const showWebContextMenu = useCallback(
+    async (menuItems: Array<NativeMenuItem>, e: MouseEvent | React.MouseEvent) => {
+      const abortController = new AbortController()
+      const resolvers = Promise.withResolvers<void>()
+      setContextMenu({
+        open: true,
+        position: { x: e.clientX, y: e.clientY },
+        menuItems,
+        abortController,
+      })
+
+      abortController.signal.addEventListener("abort", () => {
+        resolvers.resolve()
+      })
+      return resolvers.promise
+    },
+    [setContextMenu],
+  )
+
+  return showWebContextMenu
+}
+
+// Menu
+
+type BaseMenuItemText = {
+  type: "text"
+  label: string
+  click?: () => void
+  /** only work in web app */
+  icon?: React.ReactNode
+  shortcut?: string
+  disabled?: boolean
+  checked?: boolean
+  supportMultipleSelection?: boolean
+}
+
+type BaseMenuItemSeparator = {
+  type: "separator"
+  disabled?: boolean
+}
+
+type BaseMenuItem = BaseMenuItemText | BaseMenuItemSeparator
+
+export type NativeMenuItem = BaseMenuItem & {
+  submenu?: NativeMenuItem[]
+}
+
+export type NullableNativeMenuItem =
+  | (BaseMenuItemText & { hide?: boolean; submenu?: NullableNativeMenuItem[] })
+  | (BaseMenuItemSeparator & { hide?: boolean })
+  | null
+  | undefined
+  | false
+  | ""
+
+function sortShortcutsString(shortcut: string) {
+  const order = ["Shift", "Ctrl", "Meta", "Alt"]
+  let nextShortcut = shortcut
+  if (getOS() === "Windows") {
+    nextShortcut = shortcut.replace("Meta", "Ctrl").replace("meta", "ctrl")
+  }
+  const arr = nextShortcut.split("+")
+
+  const sortedModifiers = arr
+    .filter((key) => order.includes(key))
+    .sort((a, b) => order.indexOf(a) - order.indexOf(b))
+
+  const otherKeys = arr.filter((key) => !order.includes(key))
+
+  return [...sortedModifiers, ...otherKeys].join("+")
+}
+
+function normalizeMenuItems(items: NullableNativeMenuItem[]): NativeMenuItem[] {
+  return items
+    .filter((item) => item !== null && item !== undefined && item !== false && item !== "")
+    .filter((item) => !item.hide)
+    .map((item) => {
+      if (item.type === "separator") {
+        return item
+      }
+
+      return {
+        ...item,
+        shortcut: item.shortcut ? sortShortcutsString(item.shortcut) : undefined,
+        submenu: item.submenu ? normalizeMenuItems(item.submenu) : undefined,
+      }
+    })
+    .filter((item) => item !== null)
+}
+
+// MenuItem must have at least one of label, role or type
+function transformMenuItemsForNative(nextItems: NativeMenuItem[]) {
+  return nextItems.map((item) => {
+    if (item.type === "separator") {
+      return { type: "separator" }
+    }
+    return {
+      type: typeof item.checked === "boolean" ? "checkbox" : undefined,
+      label: item.label,
+      click: item.click,
+      enabled:
+        (!item.disabled && item.click !== undefined) || (!!item.submenu && item.submenu.length > 0),
+      accelerator: item.shortcut?.replace("Meta", "CmdOrCtrl"),
+      checked: typeof item.checked === "boolean" ? item.checked : undefined,
+      submenu: item.submenu ? transformMenuItemsForNative(item.submenu) : undefined,
+    } satisfies ElectronMenuItem
+  })
+}
+
+function withDebugMenu(menuItems: Array<NativeMenuItem>, e: MouseEvent | React.MouseEvent) {
+  if (import.meta.env.DEV && e) {
+    menuItems.push(
+      {
+        type: "separator" as const,
+      },
+      {
+        type: "text" as const,
+        label: "Inspect Element",
+        click: () => {
+          tipcClient?.inspectElement({
+            x: e.pageX,
+            y: e.pageY,
+          })
+        },
+      },
+    )
+  }
+  return menuItems
+}
+
+export const useShowContextMenu = () => {
+  const showWebContextMenu = useShowWebContextMenu()
+
+  const showContextMenu = useCallback(
+    async (inputMenu: Array<NullableNativeMenuItem>, e: MouseEvent | React.MouseEvent) => {
+      const menuItems = normalizeMenuItems(inputMenu)
+      // only show native menu on macOS electron, because in other platform, the native ui is not good
+      if (IN_ELECTRON && getOS() === "macOS") {
+        withDebugMenu(menuItems, e)
+        await showElectronContextMenu(transformMenuItemsForNative(menuItems))
+        return
+      }
+      await showWebContextMenu(menuItems, e)
+    },
+    [showWebContextMenu],
+  )
+
+  return showContextMenu
+}

--- a/apps/renderer/src/atoms/context-menu.ts
+++ b/apps/renderer/src/atoms/context-menu.ts
@@ -114,7 +114,6 @@ function normalizeMenuItems(items: MenuItemInput[]): FollowMenuItem[] {
         submenu: item.submenu ? normalizeMenuItems(item.submenu) : undefined,
       }
     })
-    .filter((item) => item !== null)
 }
 
 // MenuItem must have at least one of label, role or type

--- a/apps/renderer/src/hooks/biz/useFeedActions.tsx
+++ b/apps/renderer/src/hooks/biz/useFeedActions.tsx
@@ -7,9 +7,9 @@ import { isBizId } from "@follow/utils/utils"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
+import type { FollowMenuItem, MenuItemInput } from "~/atoms/context-menu"
 import { whoami } from "~/atoms/user"
 import { useModalStack } from "~/components/ui/modal/stacked/hooks"
-import type { NativeMenuItem, NullableNativeMenuItem } from "~/lib/native-menu"
 import { useBoostModal } from "~/modules/boost/hooks"
 import { useFeedClaimModal } from "~/modules/claim"
 import { FeedForm } from "~/modules/discover/feed-form"
@@ -91,7 +91,7 @@ export const useFeedActions = ({
     const related = feed || inbox
     if (!related) return []
 
-    const items: NullableNativeMenuItem[] = [
+    const items: MenuItemInput[] = [
       {
         type: "text" as const,
         label: t("sidebar.feed_actions.mark_all_as_read"),
@@ -328,7 +328,7 @@ export const useListActions = ({ listId, view }: { listId: string; view: FeedVie
   const items = useMemo(() => {
     if (!list) return []
 
-    const items: NullableNativeMenuItem[] = [
+    const items: MenuItemInput[] = [
       list.ownerUserId === whoami()?.id && {
         type: "text" as const,
         label: t("sidebar.feed_actions.list_owned_by_you"),
@@ -416,7 +416,7 @@ export const useInboxActions = ({ inboxId }: { inboxId: string }) => {
   const items = useMemo(() => {
     if (!inbox) return []
 
-    const items: NativeMenuItem[] = [
+    const items: FollowMenuItem[] = [
       {
         type: "text" as const,
         label: t("sidebar.feed_actions.edit"),

--- a/apps/renderer/src/lib/native-menu.ts
+++ b/apps/renderer/src/lib/native-menu.ts
@@ -1,165 +1,54 @@
-import { IN_ELECTRON } from "@follow/shared/constants"
-import { getOS } from "@follow/utils/utils"
-import { get } from "lodash-es"
+import type { MenuItemConstructorOptions } from "electron"
 
 import { tipcClient } from "./client"
 
-type MenuItemWithHide<T> = T & {
-  hide?: boolean
-}
-
-type BaseMenuItemText = MenuItemWithHide<{
-  type: "text"
-  label: string
+export type ElectronMenuItem = Omit<MenuItemConstructorOptions, "click" | "submenu"> & {
   click?: () => void
-  /** only work in web app */
-  icon?: React.ReactNode
-  shortcut?: string
-  disabled?: boolean
-  checked?: boolean
-  supportMultipleSelection?: boolean
-}>
-
-type BaseMenuItemSeparator = MenuItemWithHide<{
-  type: "separator"
-  disabled?: boolean
-}>
-
-type BaseMenuItem = BaseMenuItemText | BaseMenuItemSeparator
-
-export type NativeMenuItem = BaseMenuItem & {
-  submenu?: NativeMenuItem[]
+  submenu?: ElectronMenuItem[]
 }
 
-export type NullableNativeMenuItem =
-  | (BaseMenuItemText & { submenu?: NullableNativeMenuItem[] })
-  | BaseMenuItemSeparator
-  | null
-  | undefined
-  | false
-  | ""
-
-function sortShortcutsString(shortcut: string) {
-  const order = ["Shift", "Ctrl", "Meta", "Alt"]
-  let nextShortcut = shortcut
-  if (getOS() === "Windows") {
-    nextShortcut = shortcut.replace("Meta", "Ctrl").replace("meta", "ctrl")
-  }
-  const arr = nextShortcut.split("+")
-
-  const sortedModifiers = arr
-    .filter((key) => order.includes(key))
-    .sort((a, b) => order.indexOf(a) - order.indexOf(b))
-
-  const otherKeys = arr.filter((key) => !order.includes(key))
-
-  return [...sortedModifiers, ...otherKeys].join("+")
+export const showElectronContextMenu = async (items: Array<ElectronMenuItem>) => {
+  if (!window.electron) throw new Error("electron is not available")
+  const dispose = window.electron.ipcRenderer.on(
+    "menu-click",
+    (_, { path }: { path: number[] }) => {
+      const targetMenu = getMenuItemByPath(items, path)
+      if (targetMenu && typeof targetMenu.click === "function") {
+        targetMenu.click()
+      } else {
+        console.warn(`Menu item not found or click handler missing for path: ${path}`)
+      }
+    },
+  )
+  const itemsWithoutClick = removeClick(items)
+  await tipcClient?.showContextMenu({ items: itemsWithoutClick })
+  dispose()
 }
 
-function processMenuItems(items: NullableNativeMenuItem[]): NativeMenuItem[] {
-  return (items.filter((item) => item && !item.hide) as NativeMenuItem[]).map((item) => {
-    if (item.type === "text") {
+const removeClick = (item: ElectronMenuItem[]): ElectronMenuItem[] =>
+  item.map(({ click, ...rest }) => {
+    if (rest.submenu)
       return {
-        ...item,
-        shortcut: item.shortcut ? sortShortcutsString(item.shortcut) : undefined,
-        submenu: item.submenu ? processMenuItems(item.submenu) : undefined,
+        ...rest,
+        submenu: removeClick(rest.submenu),
       }
-    }
-    return item
+    return rest
   })
+
+// Function to retrieve the menu item based on the provided path
+const getMenuItemByPath = (items: ElectronMenuItem[], path: number[]): ElectronMenuItem | null => {
+  let currentItems = items
+  let currentItem: ElectronMenuItem | null = null
+
+  for (const index of path) {
+    if (!currentItems || index >= currentItems.length) return null
+    currentItem = currentItems[index]
+
+    if (currentItem.submenu && Array.isArray(currentItem.submenu)) {
+      currentItems = currentItem.submenu
+    } else {
+      currentItems = []
+    }
+  }
+  return currentItem
 }
-export const showNativeMenu = async (
-  items: Array<NullableNativeMenuItem>,
-  e?: MouseEvent | React.MouseEvent,
-) => {
-  const nextItems = processMenuItems(items)
-
-  const el = e && e.currentTarget
-
-  if (el instanceof HTMLElement) {
-    el.dataset.contextMenuOpen = "true"
-  }
-
-  // only show native menu on macOS electron, because in other platform, the native ui is not good
-  if (!IN_ELECTRON || getOS() !== "macOS") {
-    document.dispatchEvent(
-      new CustomEvent(CONTEXT_MENU_SHOW_EVENT_KEY, {
-        detail: {
-          items: nextItems,
-          x: e?.clientX,
-          y: e?.clientY,
-        },
-      }),
-    )
-    return
-  } else {
-    if (import.meta.env.DEV && e) {
-      nextItems.push(
-        {
-          type: "separator" as const,
-        },
-        {
-          type: "text" as const,
-          label: "Inspect Element",
-          click: () => {
-            tipcClient?.inspectElement({
-              x: e.pageX,
-              y: e.pageY,
-            })
-          },
-        },
-      )
-    }
-  }
-
-  const dispose = window.electron?.ipcRenderer.on("menu-click", (_, combinedIndex: string) => {
-    const arr = combinedIndex.split("-")
-    const accessors = [] as string[]
-    for (let i = 0; i < arr.length; i++) {
-      accessors.push(arr[i])
-
-      if (i !== arr.length - 1) {
-        accessors.push("submenu")
-      }
-    }
-    const item = get(nextItems, accessors)
-
-    if (item && item.type === "text") {
-      item.click?.()
-    }
-  })
-
-  window.electron?.ipcRenderer.once("menu-closed", () => {
-    dispose?.()
-    if (el instanceof HTMLElement) {
-      delete el.dataset.contextMenuOpen
-    }
-
-    // dispatch mouse move event
-    // NOTE: in order to remove the highlight of the trigger item
-    // e.g. https://vscode.dev/github/RSSNext/follow/blob/dev/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx#L80
-    document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }))
-  })
-
-  await tipcClient?.showContextMenu({
-    items: transformMenuItemsForNative(nextItems),
-  })
-
-  function transformMenuItemsForNative(nextItems: NativeMenuItem[]) {
-    return nextItems.map((item) => {
-      if (item.type === "text") {
-        return {
-          ...item,
-          icon: undefined,
-          enabled: item.click !== undefined || (!!item.submenu && item.submenu.length > 0),
-          click: undefined,
-          submenu: item.submenu ? transformMenuItemsForNative(item.submenu) : undefined,
-          shortcut: item.shortcut?.replace("Meta", "CmdOrCtrl"),
-        }
-      }
-      return item
-    })
-  }
-}
-
-export const CONTEXT_MENU_SHOW_EVENT_KEY = "contextmenu-show"

--- a/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -7,13 +7,13 @@ import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useDebounceCallback } from "usehooks-ts"
 
+import { useShowContextMenu } from "~/atoms/context-menu"
 import { useGeneralSettingKey } from "~/atoms/settings/general"
 import { useAsRead } from "~/hooks/biz/useAsRead"
 import { useEntryActions } from "~/hooks/biz/useEntryActions"
 import { useFeedActions } from "~/hooks/biz/useFeedActions"
 import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
 import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
-import { showNativeMenu } from "~/lib/native-menu"
 import type { FlatEntryModel } from "~/store/entry"
 import { entryActions } from "~/store/entry"
 
@@ -77,11 +77,12 @@ export const EntryItemWrapper: FC<
   )
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
   useAnyPointDown(() => isContextMenuOpen && setIsContextMenuOpen(false))
+  const showMenu = useShowContextMenu()
   const handleContextMenu: React.MouseEventHandler<HTMLDivElement> = useCallback(
-    (e) => {
+    async (e) => {
       e.preventDefault()
       setIsContextMenuOpen(true)
-      showNativeMenu(
+      await showMenu(
         [
           ...items
             .filter((item) => !item.hide)
@@ -110,7 +111,7 @@ export const EntryItemWrapper: FC<
         e,
       )
     },
-    [items, feedItems, t, entry.entries.id],
+    [showMenu, items, feedItems, t, entry.entries.id],
   )
 
   return (

--- a/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -1,6 +1,5 @@
 import type { FeedViewType } from "@follow/constants"
 import { views } from "@follow/constants"
-import { useAnyPointDown } from "@follow/hooks"
 import { cn } from "@follow/utils/utils"
 import type { FC, PropsWithChildren } from "react"
 import { useCallback, useState } from "react"
@@ -76,13 +75,12 @@ export const EntryItemWrapper: FC<
     [entry.entries.url],
   )
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
-  useAnyPointDown(() => isContextMenuOpen && setIsContextMenuOpen(false))
-  const showMenu = useShowContextMenu()
+  const showContextMenu = useShowContextMenu()
   const handleContextMenu: React.MouseEventHandler<HTMLDivElement> = useCallback(
     async (e) => {
       e.preventDefault()
       setIsContextMenuOpen(true)
-      await showMenu(
+      await showContextMenu(
         [
           ...items
             .filter((item) => !item.hide)
@@ -110,8 +108,9 @@ export const EntryItemWrapper: FC<
         ],
         e,
       )
+      setIsContextMenuOpen(false)
     },
-    [showMenu, items, feedItems, t, entry.entries.id],
+    [showContextMenu, items, feedItems, t, entry.entries.id],
   )
 
   return (

--- a/apps/renderer/src/modules/feed-column/category.tsx
+++ b/apps/renderer/src/modules/feed-column/category.tsx
@@ -3,7 +3,7 @@ import { LoadingCircle } from "@follow/components/ui/loading/index.jsx"
 import { useScrollViewElement } from "@follow/components/ui/scroll-area/hooks.js"
 import type { FeedViewType } from "@follow/constants"
 import { views } from "@follow/constants"
-import { useAnyPointDown, useInputComposition, useRefValue } from "@follow/hooks"
+import { useInputComposition, useRefValue } from "@follow/hooks"
 import { stopPropagation } from "@follow/utils/dom"
 import { cn, sortByAlphabet } from "@follow/utils/utils"
 import { useMutation } from "@tanstack/react-query"
@@ -13,7 +13,7 @@ import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useTranslation } from "react-i18next"
 import { useOnClickOutside } from "usehooks-ts"
 
-import type { NullableNativeMenuItem } from "~/atoms/context-menu"
+import type { MenuItemInput } from "~/atoms/context-menu"
 import { useShowContextMenu } from "~/atoms/context-menu"
 import { ROUTE_FEED_IN_FOLDER } from "~/constants"
 import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
@@ -144,9 +144,6 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
   const [isCategoryEditing, setIsCategoryEditing] = useState(false)
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
-  useAnyPointDown(() => {
-    isContextMenuOpen && setIsContextMenuOpen(false)
-  })
   const isCategoryIsWaiting = isChangePending
 
   const addMutation = useAddFeedToFeedList()
@@ -169,10 +166,10 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
               setCategoryActive()
             }
           }}
-          onContextMenu={(e) => {
+          onContextMenu={async (e) => {
             setIsContextMenuOpen(true)
 
-            showContextMenu(
+            await showContextMenu(
               [
                 {
                   type: "text",
@@ -200,7 +197,7 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
                               listId: list.id,
                             })
                           },
-                        }) as NullableNativeMenuItem,
+                        }) as MenuItemInput,
                     )
                     .concat(listList?.length > 0 ? [{ type: "separator" as const }] : [])
                     .concat([
@@ -256,6 +253,7 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
               ],
               e,
             )
+            setIsContextMenuOpen(false)
           }}
         >
           <div className="flex w-full min-w-0 items-center" onDoubleClick={toggleCategoryOpenState}>

--- a/apps/renderer/src/modules/feed-column/category.tsx
+++ b/apps/renderer/src/modules/feed-column/category.tsx
@@ -13,11 +13,11 @@ import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } fro
 import { useTranslation } from "react-i18next"
 import { useOnClickOutside } from "usehooks-ts"
 
+import type { NullableNativeMenuItem } from "~/atoms/context-menu"
+import { useShowContextMenu } from "~/atoms/context-menu"
 import { ROUTE_FEED_IN_FOLDER } from "~/constants"
 import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
 import { getRouteParams, useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
-import type { NullableNativeMenuItem } from "~/lib/native-menu"
-import { showNativeMenu } from "~/lib/native-menu"
 import { getPreferredTitle, useAddFeedToFeedList, useFeedStore } from "~/store/feed"
 import { useOwnedList } from "~/store/list"
 import {
@@ -152,6 +152,7 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
   const addMutation = useAddFeedToFeedList()
 
   const listList = useOwnedList(view!)
+  const showContextMenu = useShowContextMenu()
 
   return (
     <div tabIndex={-1} onClick={stopPropagation}>
@@ -171,7 +172,7 @@ function FeedCategoryImpl({ data: ids, view, categoryOpenStateData }: FeedCatego
           onContextMenu={(e) => {
             setIsContextMenuOpen(true)
 
-            showNativeMenu(
+            showContextMenu(
               [
                 {
                   type: "text",

--- a/apps/renderer/src/modules/feed-column/item.tsx
+++ b/apps/renderer/src/modules/feed-column/item.tsx
@@ -15,12 +15,12 @@ import dayjs from "dayjs"
 import { memo, useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { useShowContextMenu } from "~/atoms/context-menu"
 import { getMainContainerElement } from "~/atoms/dom"
 import { useFeedActions, useInboxActions, useListActions } from "~/hooks/biz/useFeedActions"
 import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
 import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 import { getNewIssueUrl } from "~/lib/issues"
-import { showNativeMenu } from "~/lib/native-menu"
 import { FeedIcon } from "~/modules/feed/feed-icon"
 import { FeedTitle } from "~/modules/feed/feed-title"
 import { getPreferredTitle, useFeedById } from "~/store/feed"
@@ -91,6 +91,7 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
   })
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
+  const showContextMenu = useShowContextMenu()
   useAnyPointDown(() => {
     isContextMenuOpen && setIsContextMenuOpen(false)
   })
@@ -139,7 +140,7 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
               },
             )
           }
-          showNativeMenu(
+          showContextMenu(
             nextItems.filter(
               (item) =>
                 selectedFeedIds.length === 0 ||
@@ -240,6 +241,7 @@ const ListItemImpl: Component<{
     },
     [listId, navigate, view],
   )
+  const showContextMenu = useShowContextMenu()
   const { t } = useTranslation()
   if (!list) return null
   return (
@@ -258,8 +260,7 @@ const ListItemImpl: Component<{
       }}
       onContextMenu={(e) => {
         setIsContextMenuOpen(true)
-
-        showNativeMenu(items, e)
+        showContextMenu(items, e)
       }}
     >
       <div className={"flex min-w-0 items-center"}>
@@ -315,6 +316,8 @@ const InboxItemImpl: Component<{
     },
     [inboxId, navigate, view],
   )
+  const showContextMenu = useShowContextMenu()
+
   if (!inbox) return null
   return (
     <div
@@ -329,7 +332,7 @@ const InboxItemImpl: Component<{
       onClick={handleNavigate}
       onContextMenu={(e) => {
         setIsContextMenuOpen(true)
-        showNativeMenu(items, e)
+        showContextMenu(items, e)
       }}
     >
       <div className={"flex min-w-0 items-center"}>

--- a/apps/renderer/src/modules/feed-column/item.tsx
+++ b/apps/renderer/src/modules/feed-column/item.tsx
@@ -7,7 +7,6 @@ import {
 } from "@follow/components/ui/tooltip/index.jsx"
 import { EllipsisHorizontalTextWithTooltip } from "@follow/components/ui/typography/index.js"
 import type { FeedViewType } from "@follow/constants"
-import { useAnyPointDown } from "@follow/hooks"
 import { nextFrame } from "@follow/utils/dom"
 import { UrlBuilder } from "@follow/utils/url-builder"
 import { cn } from "@follow/utils/utils"
@@ -92,9 +91,6 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
   const showContextMenu = useShowContextMenu()
-  useAnyPointDown(() => {
-    isContextMenuOpen && setIsContextMenuOpen(false)
-  })
   if (!feed) return null
 
   const isFeed = feed.type === "feed" || !feed.type
@@ -114,8 +110,7 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
         onDoubleClick={() => {
           window.open(UrlBuilder.shareFeed(feedId, view), "_blank")
         }}
-        onContextMenu={(e) => {
-          setIsContextMenuOpen(true)
+        onContextMenu={async (e) => {
           const nextItems = items.concat()
           if (isFeed && feed.errorAt && feed.errorMessage) {
             nextItems.push(
@@ -140,7 +135,8 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
               },
             )
           }
-          showContextMenu(
+          setIsContextMenuOpen(true)
+          await showContextMenu(
             nextItems.filter(
               (item) =>
                 selectedFeedIds.length === 0 ||
@@ -151,6 +147,7 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
             ),
             e,
           )
+          setIsContextMenuOpen(false)
         }}
       >
         <div
@@ -217,9 +214,6 @@ const ListItemImpl: Component<{
   const listUnread = useFeedUnreadStore((state) => state.data[listId] || 0)
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
-  useAnyPointDown(() => {
-    isContextMenuOpen && setIsContextMenuOpen(false)
-  })
   const subscription = useSubscriptionByFeedId(listId)
   const navigate = useNavigateEntry()
   const handleNavigate = useCallback(
@@ -258,9 +252,10 @@ const ListItemImpl: Component<{
       onDoubleClick={() => {
         window.open(UrlBuilder.shareList(listId, view), "_blank")
       }}
-      onContextMenu={(e) => {
+      onContextMenu={async (e) => {
         setIsContextMenuOpen(true)
-        showContextMenu(items, e)
+        await showContextMenu(items, e)
+        setIsContextMenuOpen(false)
       }}
     >
       <div className={"flex min-w-0 items-center"}>
@@ -300,9 +295,6 @@ const InboxItemImpl: Component<{
   const inboxUnread = useFeedUnreadStore((state) => state.data[inboxId] || 0)
 
   const [isContextMenuOpen, setIsContextMenuOpen] = useState(false)
-  useAnyPointDown(() => {
-    isContextMenuOpen && setIsContextMenuOpen(false)
-  })
   const navigate = useNavigateEntry()
   const handleNavigate = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -330,9 +322,10 @@ const InboxItemImpl: Component<{
         className,
       )}
       onClick={handleNavigate}
-      onContextMenu={(e) => {
+      onContextMenu={async (e) => {
         setIsContextMenuOpen(true)
-        showContextMenu(items, e)
+        await showContextMenu(items, e)
+        setIsContextMenuOpen(false)
       }}
     >
       <div className={"flex min-w-0 items-center"}>

--- a/apps/renderer/src/providers/context-menu-provider.tsx
+++ b/apps/renderer/src/providers/context-menu-provider.tsx
@@ -1,9 +1,10 @@
 import { nextFrame } from "@follow/utils/dom"
 import { cn } from "@follow/utils/utils"
-import type { ReactNode } from "react"
-import { Fragment, memo, useCallback, useEffect, useRef, useState } from "react"
+import { Fragment, memo, useCallback, useEffect, useRef } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 
+import type { NativeMenuItem } from "~/atoms/context-menu"
+import { useContextMenuState } from "~/atoms/context-menu"
 import {
   ContextMenu,
   ContextMenuCheckboxItem,
@@ -19,75 +20,61 @@ import {
 import { KbdCombined } from "~/components/ui/kbd/Kbd"
 import { HotKeyScopeMap } from "~/constants"
 import { useSwitchHotKeyScope } from "~/hooks/common"
-import type { NativeMenuItem } from "~/lib/native-menu"
-import { CONTEXT_MENU_SHOW_EVENT_KEY } from "~/lib/native-menu"
 
 export const ContextMenuProvider: Component = ({ children }) => (
   <>
     {children}
-
     <Handler />
   </>
 )
 
 const Handler = () => {
   const ref = useRef<HTMLSpanElement>(null)
-
-  const [node, setNode] = useState([] as ReactNode[] | ReactNode)
-
-  const [open, setOpen] = useState(false)
+  const [contextMenuState, setContextMenuState] = useContextMenuState()
 
   const switchHotkeyScope = useSwitchHotKeyScope()
 
   useEffect(() => {
-    if (!open) return
+    if (!contextMenuState.open) return
     switchHotkeyScope("Menu")
     return () => {
       switchHotkeyScope("Home")
     }
-  }, [open, switchHotkeyScope])
+  }, [contextMenuState.open, switchHotkeyScope])
 
   useEffect(() => {
-    const fakeElement = ref.current
-    if (!fakeElement) return
-    const handler = (e: unknown) => {
-      const bizEvent = e as {
-        detail?: {
-          items: NativeMenuItem[]
-          x: number
-          y: number
-        }
-      }
-      if (!bizEvent.detail) return
+    if (!contextMenuState.open) return
+    const triggerElement = ref.current
+    if (!triggerElement) return
+    // [ContextMenu] Add ability to control
+    // https://github.com/radix-ui/primitives/issues/1307#issuecomment-1689754796
+    triggerElement.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX: contextMenuState.position.x,
+        clientY: contextMenuState.position.y,
+      }),
+    )
+  }, [contextMenuState])
 
-      if (!("items" in bizEvent.detail) || !("x" in bizEvent.detail) || !("y" in bizEvent.detail)) {
-        return
-      }
-      if (!Array.isArray(bizEvent.detail?.items)) return
-
-      setNode(bizEvent.detail.items.map((item, index) => <Item key={index} item={item} />))
-
-      fakeElement.dispatchEvent(
-        new MouseEvent("contextmenu", {
-          bubbles: true,
-          cancelable: true,
-          clientX: bizEvent.detail.x,
-          clientY: bizEvent.detail.y,
-        }),
-      )
-    }
-
-    // eslint-disable-next-line @eslint-react/web-api/no-leaked-event-listener
-    document.addEventListener(CONTEXT_MENU_SHOW_EVENT_KEY, handler)
-    return () => {
-      document.removeEventListener(CONTEXT_MENU_SHOW_EVENT_KEY, handler)
-    }
-  }, [])
+  const handleOpenChange = useCallback(
+    (state: boolean) => {
+      if (state) return
+      if (!contextMenuState.open) return
+      setContextMenuState({ open: false })
+      contextMenuState.abortController.abort()
+    },
+    [contextMenuState, setContextMenuState],
+  )
 
   return (
-    <ContextMenu onOpenChange={setOpen}>
+    <ContextMenu onOpenChange={handleOpenChange}>
       <ContextMenuTrigger className="hidden" ref={ref} />
-      <ContextMenuContent>{node}</ContextMenuContent>
+      <ContextMenuContent>
+        {contextMenuState.open &&
+          contextMenuState.menuItems.map((item, index) => <Item key={index} item={item} />)}
+      </ContextMenuContent>
     </ContextMenu>
   )
 }
@@ -110,10 +97,6 @@ const Item = memo(({ item }: { item: NativeMenuItem }) => {
     preventDefault: true,
   })
 
-  if (item.hide) {
-    return null
-  }
-
   switch (item.type) {
     case "separator": {
       return <ContextMenuSeparator />
@@ -131,7 +114,7 @@ const Item = memo(({ item }: { item: NativeMenuItem }) => {
         <Sub>
           <Wrapper
             ref={itemRef}
-            disabled={item.click === undefined && !item.submenu}
+            disabled={item.disabled || (item.click === undefined && !item.submenu)}
             onClick={onClick}
             className="flex items-center gap-2"
             checked={item.checked}

--- a/apps/renderer/src/providers/context-menu-provider.tsx
+++ b/apps/renderer/src/providers/context-menu-provider.tsx
@@ -3,7 +3,7 @@ import { cn } from "@follow/utils/utils"
 import { Fragment, memo, useCallback, useEffect, useRef } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 
-import type { NativeMenuItem } from "~/atoms/context-menu"
+import type { FollowMenuItem } from "~/atoms/context-menu"
 import { useContextMenuState } from "~/atoms/context-menu"
 import {
   ContextMenu,
@@ -79,7 +79,7 @@ const Handler = () => {
   )
 }
 
-const Item = memo(({ item }: { item: NativeMenuItem }) => {
+const Item = memo(({ item }: { item: FollowMenuItem }) => {
   const onClick = useCallback(() => {
     if ("click" in item) {
       // Here we need to delay one frame,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,7 @@ export default ({ mode }) => {
           renderLegacyChunks: false,
           modernTargets: ">0.3%, last 2 versions, Firefox ESR, not dead",
           modernPolyfills: [
+            // https://unpkg.com/browse/core-js@3.39.0/modules/
             "es.array.find-last-index",
             "es.array.find-last",
             "es.promise.with-resolvers",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -69,7 +69,11 @@ export default ({ mode }) => {
           targets: "defaults",
           renderLegacyChunks: false,
           modernTargets: ">0.3%, last 2 versions, Firefox ESR, not dead",
-          modernPolyfills: ["es.array.find-last-index", "es.array.find-last"],
+          modernPolyfills: [
+            "es.array.find-last-index",
+            "es.array.find-last",
+            "es.promise.with-resolvers",
+          ],
         }),
       htmlInjectPlugin(typedEnv),
       mkcert(),


### PR DESCRIPTION
Introduce new context menu functionality while simplifying the existing native menu structure.

Update naming conventions and replace native menu calls with context menu hooks for improved consistency and maintainability.

This pr improves the context menu by:

- Split native menu and web menu
- Move the web menu out of the `native-menu.ts`
- Return a promise within the `showContextMenu` fn.
- Sunset uses `useAnyPointDown` to keep track of the menu's state.