### PR TITLE
fix(ui): resolve conflict between video progress bar and swiper drag …

### DIFF
--- a/apps/renderer/src/components/ui/media/VideoPlayer.tsx
+++ b/apps/renderer/src/components/ui/media/VideoPlayer.tsx
@@ -377,7 +377,7 @@ const PlayProgressBar = () => {
   })
   return (
     <Slider.Root
-      className="relative z-[1] flex size-full items-center transition-all duration-200 ease-in-out"
+      className="swiper-no-swiping relative z-[1] flex size-full items-center transition-all duration-200 ease-in-out"
       min={0}
       max={state.duration}
       step={0.01}


### PR DESCRIPTION
…interaction

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
When displaying multiple media items including videos in Swiper, the video progress bar becomes unusable because Swiper's drag-to-switch interaction takes precedence. 
This makes it impossible to seek through the video using the progress bar, as any click or drag on the progress bar triggers a media switch instead.

https://github.com/user-attachments/assets/796c8de1-1e84-4144-9e15-bef2a8876acd


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
