### PR TITLE
feat: add application tray functionality

### DIFF
--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -11,6 +11,7 @@ import { initializeAppStage0, initializeAppStage1 } from "./init"
 import { updateProxy } from "./lib/proxy"
 import { handleUrlRouting } from "./lib/router"
 import { store } from "./lib/store"
+import { registerAppTray } from "./lib/tray"
 import { setAuthSessionToken, updateNotificationsToken } from "./lib/user"
 import { registerUpdater } from "./updater"
 import { createMainWindow, getMainWindow, windowStateStoreKey } from "./window"
@@ -65,6 +66,7 @@ function bootstrap() {
 
     updateProxy()
     registerUpdater()
+    registerAppTray()
 
     session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
       // remove Electron, Follow from user agent

--- a/apps/main/src/lib/tray.ts
+++ b/apps/main/src/lib/tray.ts
@@ -1,0 +1,22 @@
+import { app, nativeImage, Tray } from "electron"
+
+import { getIconPath } from "~/helper"
+
+import { getMainWindow } from "../window"
+
+export const registerAppTray = () => {
+  const icon = nativeImage.createFromPath(getIconPath())
+  // See https://stackoverflow.com/questions/41664208/electron-tray-icon-change-depending-on-dark-theme/41998326#41998326
+  const trayIcon = icon.resize({ width: 16 })
+  const tray = new Tray(trayIcon)
+
+  tray.on("click", () => {
+    const mainWindow = getMainWindow()
+    if (mainWindow?.isMinimized()) {
+      mainWindow.restore()
+    } else {
+      mainWindow?.show()
+    }
+  })
+  tray.setToolTip(app.getName())
+}


### PR DESCRIPTION
Fix https://github.com/RSSNext/Follow/issues/177 https://github.com/RSSNext/Follow/issues/999

Introduce an application tray that allows users to interact with the main window through a system tray icon.