### PR TITLE
fix: handling default port in proxy configuration

### DIFF
--- a/apps/main/src/lib/proxy.test.ts
+++ b/apps/main/src/lib/proxy.test.ts
@@ -40,6 +40,14 @@ describe("proxy", () => {
       expect(result).toBe(true)
     })
 
+    it("should handle default port", () => {
+      // https://github.com/RSSNext/Follow/issues/1197
+      const proxy = "http://example.com:80"
+      const result = setProxyConfig(proxy)
+      expect(store.set).toHaveBeenCalledWith("proxy", "http://example.com")
+      expect(result).toBe(true)
+    })
+
     it("should return false for invalid proxy", () => {
       const proxy = "invalid-proxy"
       const result = setProxyConfig(proxy)

--- a/apps/main/src/lib/proxy.ts
+++ b/apps/main/src/lib/proxy.ts
@@ -43,12 +43,12 @@ const normalizeProxyUri = (userProxy: string) => {
 
   try {
     const proxyUrl = new URL(firstInput)
-    if (!URL_SCHEME.has(proxyUrl.protocol) || !proxyUrl.hostname || !proxyUrl.port) {
+    if (!URL_SCHEME.has(proxyUrl.protocol) || !proxyUrl.hostname) {
       return
     }
     // There are multiple ways to specify a proxy in Electron,
     // but for security reasons, we only support simple proxy URLs for now.
-    return `${proxyUrl.protocol}//${proxyUrl.hostname}:${proxyUrl.port}`
+    return `${proxyUrl.protocol}//${proxyUrl.hostname}${proxyUrl.port ? `:${proxyUrl.port}` : ""}`
   } catch {
     return
   }


### PR DESCRIPTION
Fix https://github.com/RSSNext/Follow/issues/1197

### Description

Handling default port in proxy configuration

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
