### PR TITLE
fix: not showing feed certification icon on the sidebar

### DIFF
--- a/apps/renderer/src/modules/feed-column/item.tsx
+++ b/apps/renderer/src/modules/feed-column/item.tsx
@@ -51,6 +51,8 @@ const FeedItemImpl = ({ view, feedId, className }: FeedItemProps) => {
       url: feed.url,
       image: feed.image,
       siteUrl: feed.siteUrl,
+      ownerUserId: feed.ownerUserId,
+      owner: feed.owner,
     }
   })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes the issue that feed certification icon not being shown on the sidebar due to the missing `ownerUserId` and `owner` fields.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Additional context

<img width="400" alt="Follow sidebar missing certification icon" src="https://github.com/user-attachments/assets/e1dc80b3-3130-470d-8a3b-5fbbeda85280">