### PR TITLE
fix: app upgraded toast href error

### DIFF
--- a/apps/renderer/src/modules/upgrade/container.tsx
+++ b/apps/renderer/src/modules/upgrade/container.tsx
@@ -57,7 +57,7 @@ const AppNotificationContainer: FC = () => {
         <div>
           App is upgraded to{" "}
           <a
-            href={`${repository.url}/releases/tag/${APP_VERSION}`}
+            href={`${repository.url}/releases/tag/v${APP_VERSION}`}
             target="_blank"
             rel="noreferrer"
           >


### PR DESCRIPTION
 ### Description

The link in the bottom right corner where the toast pops up the first time you open it is the wrong link. "https://github.com/RSSNext/Follow/releases/tag/v0.1.2-beta.0", and it goes to “https://github.com/RSSNext/Follow/releases/tag/0.1.2-beta.0” which is a 404 error.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [ ] Bugfix
- [ ] Hotfix
- [x] Other (please describe): link error

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
