### PR TITLE
fix: prevent default scrolling behavior while using arrow keys to switch between entries

### DIFF
--- a/apps/renderer/src/modules/entry-column/EntryColumnShortcutHandler.tsx
+++ b/apps/renderer/src/modules/entry-column/EntryColumnShortcutHandler.tsx
@@ -67,7 +67,7 @@ export const EntryColumnShortcutHandler: FC<{
         entryId: nextId,
       })
     },
-    { scopes: HotKeyScopeMap.Home, enabled: enabledArrowKey },
+    { scopes: HotKeyScopeMap.Home, enabled: enabledArrowKey, preventDefault: true },
   )
   useHotkeys(
     shortcuts.entries.previous.key,
@@ -87,7 +87,7 @@ export const EntryColumnShortcutHandler: FC<{
         entryId: nextId,
       })
     },
-    { scopes: HotKeyScopeMap.Home, enabled: enabledArrowKey },
+    { scopes: HotKeyScopeMap.Home, enabled: enabledArrowKey, preventDefault: true },
   )
   return null
 })

--- a/changelog/next.md
+++ b/changelog/next.md
@@ -15,4 +15,4 @@
 
 ## Bug Fixes
 
-- Default scrolling behavior is prevented while using arrow keys to switch between entries.
+- While using arrow keys to switch between entries, the entry view will not scroll unexpexted.

--- a/changelog/next.md
+++ b/changelog/next.md
@@ -14,3 +14,5 @@
 - Improvement web app global shortcuts.
 
 ## Bug Fixes
+
+- Default scrolling behavior is prevented while using arrow keys to switch between entries.


### PR DESCRIPTION
While using up and down arrow to switch between feed entries, the web will scroll a little. 

https://github.com/user-attachments/assets/a38dfba3-eeed-4213-bb63-32607247b33c

By preventing the default scrolling behavior of the arrow key, we avoid it. 

https://github.com/user-attachments/assets/2144e6f1-4a88-4018-89e3-61727b4923fe

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [x] I have updated the changelog/next.md with my changes.
