### PR TITLE
fix: update daily claim amount reference in tooltip

### DIFF
--- a/apps/renderer/src/modules/power/my-wallet-section/claim-daily-reward.tsx
+++ b/apps/renderer/src/modules/power/my-wallet-section/claim-daily-reward.tsx
@@ -31,7 +31,7 @@ export const ClaimDailyReward = () => {
           <Trans
             i18nKey="wallet.claim.tooltip.canClaim"
             ns="settings"
-            values={{ amount: serverConfigs?.DAILY_CLAIM_AMOUNT }}
+            values={{ amount: serverConfigs?.DAILY_CLAIM_AMOUNT.normal }}
           />
         ) : (
           t("wallet.claim.tooltip.alreadyClaimed")


### PR DESCRIPTION
I wonder if it is better to remove the amount here. And actually `DAILY_CLAIM_AMOUNT.normal` isn't the real count I get today.

Before:

<img width="403" alt="image" src="https://github.com/user-attachments/assets/906f3de2-16fa-4254-870d-a89ce6d04925">

After:

<img width="276" alt="image" src="https://github.com/user-attachments/assets/ae6f8730-1d59-4c32-8fdb-3ff46531140a">