### PR TITLE
feat: add feed booster achievement with localization

### DIFF
--- a/apps/renderer/src/modules/achievement/AchievementModalContent.tsx
+++ b/apps/renderer/src/modules/achievement/AchievementModalContent.tsx
@@ -33,6 +33,7 @@ enum AchievementsActionIdMap {
   // TODO
   // FOLLOW_SPECIAL_FEED = 6,
   ALPHA_TESTER = 7,
+  FEED_BOOSTER = 8,
 }
 
 const achievementActionIdCopyMap: Record<
@@ -70,6 +71,10 @@ const achievementActionIdCopyMap: Record<
   [AchievementsActionIdMap.ALPHA_TESTER]: {
     title: "achievement.alpha_tester",
     description: "achievement.alpha_tester_description",
+  },
+  [AchievementsActionIdMap.FEED_BOOSTER]: {
+    title: "achievement.feed_booster",
+    description: "achievement.feed_booster_description",
   },
 }
 

--- a/apps/renderer/src/modules/boost/level-benefits.tsx
+++ b/apps/renderer/src/modules/boost/level-benefits.tsx
@@ -9,7 +9,7 @@ const benefits = [
         text: "Unique boost badge for feed",
       },
       { icon: "i-mgc-star-cute-re", text: "Support feed owner" },
-      { icon: "i-mgc-trophy-cute-re", text: "Booster achievement", comingSoon: true },
+      { icon: "i-mgc-trophy-cute-re", text: "Booster achievement" },
       { icon: "i-mgc-rocket-cute-re", text: "Faster feed refresh time", comingSoon: true },
     ],
   },

--- a/locales/app/en.json
+++ b/locales/app/en.json
@@ -3,6 +3,8 @@
   "achievement.alpha_tester": "Alpha Tester",
   "achievement.alpha_tester_description": "You are an alpha tester of Follow",
   "achievement.description": "Be a hardcore player and mint NFTs.",
+  "achievement.feed_booster": "Feed Booster",
+  "achievement.feed_booster_description": "You boosted the feed on Follow",
   "achievement.first_claim_feed": "Feed Owner",
   "achievement.first_claim_feed_description": "You own your feed on Follow",
   "achievement.first_create_list": "List Creator",

--- a/locales/app/zh-CN.json
+++ b/locales/app/zh-CN.json
@@ -3,6 +3,8 @@
   "achievement.alpha_tester": "Alpha 内测用户",
   "achievement.alpha_tester_description": "早期 Follow Alpha 版本的内测用户",
   "achievement.description": "成为硬核玩家，赚取 NFT。",
+  "achievement.feed_booster": "订阅源助力者",
+  "achievement.feed_booster_description": "在 Follow 上助力订阅源",
   "achievement.first_claim_feed": "订阅源所有者",
   "achievement.first_claim_feed_description": "在 Follow 上认证订阅源",
   "achievement.first_create_list": "列表创作者",


### PR DESCRIPTION
Introduce a new achievement for boosting the feed, along with its localization in English and Chinese.

Related to https://github.com/RSSNext/follow-server/pull/170