### PR TITLE
fix: reorder "clear all data" dialog buttons and update response handling

### DIFF
--- a/apps/main/src/lib/cleaner.ts
+++ b/apps/main/src/lib/cleaner.ts
@@ -26,9 +26,8 @@ export const clearAllDataAndConfirm = async () => {
     type: "warning",
     icon: getIconPath(),
     message: t("dialog.clearAllData"),
-    buttons: [t("dialog.no"), t("dialog.yes")],
+    buttons: [t("dialog.yes"), t("dialog.no")],
     cancelId: 0,
-    defaultId: 1,
   })
 
   if (result.response === 0) {

--- a/apps/main/src/lib/cleaner.ts
+++ b/apps/main/src/lib/cleaner.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util"
 import { callWindowExpose } from "@follow/shared/bridge"
 import { app, dialog } from "electron"
 
+import { getIconPath } from "~/helper"
 import { logger } from "~/logger"
 import { getMainWindow } from "~/window"
 
@@ -23,7 +24,7 @@ export const clearAllDataAndConfirm = async () => {
   // Dialog to confirm
   const result = await dialog.showMessageBox({
     type: "warning",
-
+    icon: getIconPath(),
     message: t("dialog.clearAllData"),
     buttons: [t("dialog.no"), t("dialog.yes")],
     cancelId: 0,

--- a/apps/main/src/lib/cleaner.ts
+++ b/apps/main/src/lib/cleaner.ts
@@ -25,10 +25,12 @@ export const clearAllDataAndConfirm = async () => {
     type: "warning",
 
     message: t("dialog.clearAllData"),
-    buttons: [t("dialog.yes"), t("dialog.no")],
+    buttons: [t("dialog.no"), t("dialog.yes")],
+    cancelId: 0,
+    defaultId: 1,
   })
 
-  if (result.response === 1) {
+  if (result.response === 0) {
     return
   }
   return clearAllData()


### PR DESCRIPTION
### Description

If the button order is specified as "Yes, No":
- In English UI,  it will actually be displayed as "No, Yes".
- In Non-English UI,  it will be displayed as "Yes (translated), No (translated)", but the ESC key is assigned  to "Yes", which leads to the data being cleared after pressing the ESC key.

The reason is that Electron assigns the latin string "Yes" to the "Confirmation" action and "No" to the "Cancel" action. Although the display order of the buttons is reversed in the English UI, the value responded when pressing the ESC key is correct (index value of the "No" button). However, in the translated UI, the default value responded when pressing the ESC key is 0 (if the correct value is not assigned to `cancelId`).

Therefore, explicitly assign a value to `cancelId`.

> tested only on macOS

![image](https://github.com/user-attachments/assets/fa220038-37d6-4aea-80ad-4d02cb818a80)

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
