### PR TITLE
fix: explicitly assign a value to `cancelId` for ‘Clear All Data' dialog

### DIFF
--- a/apps/main/src/lib/cleaner.ts
+++ b/apps/main/src/lib/cleaner.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util"
 import { callWindowExpose } from "@follow/shared/bridge"
 import { app, dialog } from "electron"
 
+import { getIconPath } from "~/helper"
 import { logger } from "~/logger"
 import { getMainWindow } from "~/window"
 
@@ -23,9 +24,10 @@ export const clearAllDataAndConfirm = async () => {
   // Dialog to confirm
   const result = await dialog.showMessageBox({
     type: "warning",
-
+    icon: getIconPath(),
     message: t("dialog.clearAllData"),
     buttons: [t("dialog.yes"), t("dialog.no")],
+    cancelId: 1,
   })
 
   if (result.response === 1) {


### PR DESCRIPTION

### Description

The Electron assigns the latin string "Yes" to the "Confirmation" action and "No" to the "Cancel" action. Although the display order of the buttons is reversed in the English UI, the value responded when pressing the ESC key is correct (index value of the "No" button). However, in the translated UI, the default value responded when pressing the ESC key is 0 (if the correct value is not assigned to `cancelId`), which leads to the data being cleared after pressing the ESC key.

Therefore, explicitly assign a value to `cancelId`.

![image](https://github.com/user-attachments/assets/fa220038-37d6-4aea-80ad-4d02cb818a80)

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
