### PR TITLE
refactor: update useRouteParams hook to prevent unnecessary re-renders

### DIFF
--- a/apps/renderer/src/hooks/biz/useRouteParams.ts
+++ b/apps/renderer/src/hooks/biz/useRouteParams.ts
@@ -76,6 +76,12 @@ const parseRouteParams = (params: Params<any>, search: URLSearchParams): BizRout
   }
 }
 
+/**
+ * This hook is deprecated due to causing unnecessary re-renders.
+ * see https://github.com/remix-run/react-router/issues/7318
+ *
+ * @deprecated Use {@link useRouteParamsSelector} instead.
+ */
 export const useRouteParams = () => {
   const params = useParams()
   const [search] = useSearchParams()
@@ -83,6 +89,7 @@ export const useRouteParams = () => {
   return parseRouteParams(params, search)
 }
 const noop = [] as any[]
+
 export const useRouteParamsSelector = <T>(
   selector: (params: BizRouteParams) => T,
   deps = noop,

--- a/apps/renderer/src/hooks/biz/useRouteParams.ts
+++ b/apps/renderer/src/hooks/biz/useRouteParams.ts
@@ -76,18 +76,10 @@ const parseRouteParams = (params: Params<any>, search: URLSearchParams): BizRout
   }
 }
 
-/**
- * This hook is deprecated due to causing unnecessary re-renders.
- * see https://github.com/remix-run/react-router/issues/7318
- *
- * @deprecated Use {@link useRouteParamsSelector} instead.
- */
 export const useRouteParams = () => {
-  const params = useParams()
-  const [search] = useSearchParams()
-
-  return parseRouteParams(params, search)
+  return useRouteParamsSelector((s) => s)
 }
+
 const noop = [] as any[]
 
 export const useRouteParamsSelector = <T>(

--- a/apps/renderer/src/modules/entry-column/hooks.ts
+++ b/apps/renderer/src/modules/entry-column/hooks.ts
@@ -5,7 +5,7 @@ import type { ListRange } from "react-virtuoso"
 import { useDebounceCallback } from "usehooks-ts"
 
 import { useGeneralSettingKey } from "~/atoms/settings/general"
-import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
+import { useRouteParams, useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 import { useAuthQuery } from "~/hooks/common"
 import { apiClient, apiFetch } from "~/lib/api-fetch"
 import { entries, useEntries } from "~/queries/entries"
@@ -60,9 +60,7 @@ export const useEntriesByView = ({
   onReset?: () => void
   isArchived?: boolean
 }) => {
-  const { feedId, isAllFeeds, view, isCollection, inboxId, listId } = useRouteParamsSelector(
-    (s) => s,
-  )
+  const { feedId, isAllFeeds, view, isCollection, inboxId, listId } = useRouteParams()
 
   const unreadOnly = useGeneralSettingKey("unreadOnly")
 

--- a/apps/renderer/src/modules/entry-column/hooks.ts
+++ b/apps/renderer/src/modules/entry-column/hooks.ts
@@ -5,7 +5,7 @@ import type { ListRange } from "react-virtuoso"
 import { useDebounceCallback } from "usehooks-ts"
 
 import { useGeneralSettingKey } from "~/atoms/settings/general"
-import { useRouteParams, useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
+import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 import { useAuthQuery } from "~/hooks/common"
 import { apiClient, apiFetch } from "~/lib/api-fetch"
 import { entries, useEntries } from "~/queries/entries"
@@ -60,10 +60,11 @@ export const useEntriesByView = ({
   onReset?: () => void
   isArchived?: boolean
 }) => {
-  const routeParams = useRouteParams()
-  const unreadOnly = useGeneralSettingKey("unreadOnly")
+  const { feedId, isAllFeeds, view, isCollection, inboxId, listId } = useRouteParamsSelector(
+    (s) => s,
+  )
 
-  const { feedId, view, isAllFeeds, isCollection, listId, inboxId } = routeParams
+  const unreadOnly = useGeneralSettingKey("unreadOnly")
 
   const folderIds = useFolderFeedsByFeedId({
     feedId,

--- a/apps/renderer/src/store/feed/hooks.ts
+++ b/apps/renderer/src/store/feed/hooks.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
 import { FEED_COLLECTION_LIST, ROUTE_FEED_IN_FOLDER, ROUTE_FEED_PENDING } from "~/constants"
-import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
+import { useRouteParams } from "~/hooks/biz/useRouteParams"
 
 import { useInboxStore } from "../inbox"
 import { useListStore } from "../list"
@@ -71,7 +71,7 @@ export const useInboxByIdSelector = <T>(
 
 export const useFeedHeaderTitle = () => {
   const { t } = useTranslation()
-  const { feedId: currentFeedId, view, inboxId, listId } = useRouteParamsSelector((s) => s)
+  const { feedId: currentFeedId, view, listId, inboxId } = useRouteParams()
 
   const listTitle = useListByIdSelector(listId, getPreferredTitle)
   const inboxTitle = useInboxByIdSelector(inboxId, getPreferredTitle)

--- a/apps/renderer/src/store/feed/hooks.ts
+++ b/apps/renderer/src/store/feed/hooks.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
 import { FEED_COLLECTION_LIST, ROUTE_FEED_IN_FOLDER, ROUTE_FEED_PENDING } from "~/constants"
-import { useRouteParams } from "~/hooks/biz/useRouteParams"
+import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 
 import { useInboxStore } from "../inbox"
 import { useListStore } from "../list"
@@ -71,8 +71,7 @@ export const useInboxByIdSelector = <T>(
 
 export const useFeedHeaderTitle = () => {
   const { t } = useTranslation()
-
-  const { feedId: currentFeedId, view, listId, inboxId } = useRouteParams()
+  const { feedId: currentFeedId, view, inboxId, listId } = useRouteParamsSelector((s) => s)
 
   const listTitle = useListByIdSelector(listId, getPreferredTitle)
   const inboxTitle = useInboxByIdSelector(inboxId, getPreferredTitle)

--- a/packages/components/src/atoms/route.ts
+++ b/packages/components/src/atoms/route.ts
@@ -3,6 +3,7 @@ import { atom, useAtomValue } from "jotai"
 import { selectAtom } from "jotai/utils"
 import { useMemo } from "react"
 import type { Location, NavigateFunction, Params } from "react-router"
+import { shallow } from "zustand/shallow"
 
 interface RouteAtom {
   params: Readonly<Params<string>>
@@ -29,7 +30,8 @@ const noop = []
 export const useReadonlyRouteSelector = <T>(
   selector: (route: RouteAtom) => T,
   deps: any[] = noop,
-): T => useAtomValue(useMemo(() => selectAtom(routeAtom, (route) => selector(route)), deps))
+): T =>
+  useAtomValue(useMemo(() => selectAtom(routeAtom, (route) => selector(route), shallow), deps))
 
 // Vite HMR will create new router instance, but RouterProvider always stable
 


### PR DESCRIPTION
Replace the deprecated useRouteParams hook with useRouteParamsSelector to optimize performance and prevent unnecessary re-renders.

Update all relevant components to use the new hook.
