### PR TITLE
fix: prevent default click behavior in Media

### DIFF
--- a/apps/renderer/src/components/ui/media.tsx
+++ b/apps/renderer/src/components/ui/media.tsx
@@ -135,6 +135,7 @@ const MediaImpl: FC<MediaProps> = ({
   const isError = currentState === "error"
   const previewMedia = usePreviewMedia()
   const handleClick = useEventCallback((e: React.MouseEvent) => {
+    e.preventDefault()
     if (popper && src) {
       const width = Number.parseInt(props.width as string)
       const height = Number.parseInt(props.height as string)


### PR DESCRIPTION
Fix https://github.com/RSSNext/Follow/issues/1757

Also related to https://github.com/RSSNext/Follow/pull/1760

Ensure that the default click behavior is prevented in the Media component to enhance user interaction.