### PR TITLE
fix: optimize audio source comparison in audio player

### DIFF
--- a/apps/renderer/src/atoms/player.ts
+++ b/apps/renderer/src/atoms/player.ts
@@ -81,7 +81,10 @@ export const AudioPlayer = {
       listId: routeParams.listId,
     })
 
-    if (this.audio.src !== v.src) {
+    const currentUrl = new URL(this.audio.src, window.location.href).toString()
+    const newUrl = new URL(v.src, window.location.href).toString()
+
+    if (currentUrl !== newUrl) {
       this.audio.src = v.src
       this.audio.currentTime = v.currentTime ?? curV.currentTime ?? 0
     }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When there is Chinese in the link, the audio src comparison is always false, causing the audio to play from the beginning

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
