### PR TITLE
fix: handle popstate for navigation in mobile entry content

### DIFF
--- a/apps/renderer/src/modules/entry-content/index.mobile.tsx
+++ b/apps/renderer/src/modules/entry-content/index.mobile.tsx
@@ -5,13 +5,13 @@ import { stopPropagation } from "@follow/utils/dom"
 import { cn } from "@follow/utils/utils"
 import { ErrorBoundary } from "@sentry/react"
 import { useEffect, useMemo, useState } from "react"
-import { useNavigate } from "react-router"
 
 import { useShowAITranslation } from "~/atoms/ai-translation"
 import { useAudioPlayerAtomSelector } from "~/atoms/player"
 import { useGeneralSettingSelector } from "~/atoms/settings/general"
 import { useUISettingKey } from "~/atoms/settings/ui"
 import { ShadowDOM } from "~/components/common/ShadowDOM"
+import { useNavigateEntry } from "~/hooks/biz/useNavigateEntry"
 import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 import { useAuthQuery, usePreventOverscrollBounce } from "~/hooks/common"
 import { LanguageMap } from "~/lib/translate"
@@ -41,13 +41,14 @@ export const EntryContent: Component<{
   compact?: boolean
   classNames?: EntryContentClassNames
 }> = ({ entryId, noMedia, compact, classNames }) => {
-  const navigate = useNavigate()
+  const navigateEntry = useNavigateEntry()
+  const { entryId: _, ...params } = useRouteParamsSelector((route) => route)
 
   useEffect(() => {
     const handlePopState = (event: PopStateEvent) => {
       event.preventDefault()
       // This is triggered when the back button is pressed
-      navigate("/feeds/all/pending")
+      navigateEntry({ entryId: null, ...params })
     }
 
     // Listen to the popstate event (back button)
@@ -57,7 +58,7 @@ export const EntryContent: Component<{
     return () => {
       window.removeEventListener("popstate", handlePopState)
     }
-  }, [navigate])
+  }, [navigateEntry, params])
 
   const entry = useEntry(entryId)
   useTitle(entry?.entries.title)

--- a/apps/renderer/src/modules/entry-content/index.mobile.tsx
+++ b/apps/renderer/src/modules/entry-content/index.mobile.tsx
@@ -4,7 +4,8 @@ import type { FeedModel, InboxModel, SupportedLanguages } from "@follow/models/t
 import { stopPropagation } from "@follow/utils/dom"
 import { cn } from "@follow/utils/utils"
 import { ErrorBoundary } from "@sentry/react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router"
 
 import { useShowAITranslation } from "~/atoms/ai-translation"
 import { useAudioPlayerAtomSelector } from "~/atoms/player"
@@ -40,6 +41,24 @@ export const EntryContent: Component<{
   compact?: boolean
   classNames?: EntryContentClassNames
 }> = ({ entryId, noMedia, compact, classNames }) => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      event.preventDefault()
+      // This is triggered when the back button is pressed
+      navigate("/feeds/all/pending")
+    }
+
+    // Listen to the popstate event (back button)
+    window.addEventListener("popstate", handlePopState)
+
+    // Clean up the event listener on unmount
+    return () => {
+      window.removeEventListener("popstate", handlePopState)
+    }
+  }, [navigate])
+
   const entry = useEntry(entryId)
   useTitle(entry?.entries.title)
 

--- a/changelog/next.md
+++ b/changelog/next.md
@@ -5,3 +5,5 @@
 ## Improvements
 
 ## Bug Fixes
+
+- Resolved issue where back navigation to the pending view would not behave correctly after changing orientation in some device.


### PR DESCRIPTION


<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Resolved issue where back navigation to the pending view would not behave correctly after changing orientation in some device.

Before: after changing the orientation, the `BACK` button is navigate to previous feeds, which is expected to navigate to all feeds view. 

https://github.com/user-attachments/assets/92237fe1-706a-44bd-9425-4bf9b1f3ca7a

After: now the back navigation will be force pushed to previous feed list. 

https://github.com/user-attachments/assets/53278b62-bd29-4da9-9925-253d2ec8cf54

For some iPad users, using **Landscape** orientation to browser the list and preview on right, while using **Portrait** orientation for reading provides excellent experience. This PR will improve experience in this situation. 


### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [x] I have updated the changelog/next.md with my changes.
