### PR TITLE
fix: discover form button disable state error

### DIFF
--- a/apps/renderer/src/modules/discover/form.tsx
+++ b/apps/renderer/src/modules/discover/form.tsx
@@ -123,7 +123,7 @@ export function DiscoverForm({ type = "search" }: { type?: string }) {
     (event: ChangeEvent<HTMLInputElement>) => {
       const trimmedKeyword = event.target.value.trimStart()
       if (!prefix) {
-        form.setValue("keyword", trimmedKeyword)
+        form.setValue("keyword", trimmedKeyword, { shouldValidate: true })
         return
       }
       const isValidPrefix = prefix.find((p) => trimmedKeyword.startsWith(p))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
The search button on the Discover page should become valid when user input

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
