### PR TITLE
fix(header): improve border visibility for meta display

### DIFF
--- a/apps/renderer/src/modules/entry-content/header.desktop.tsx
+++ b/apps/renderer/src/modules/entry-content/header.desktop.tsx
@@ -29,8 +29,8 @@ function EntryHeaderImpl({ view, entryId, className, compact }: EntryHeaderProps
     <div
       data-hide-in-print
       className={cn(
-        "relative flex min-w-0 items-center justify-between gap-3 overflow-hidden text-lg text-zinc-500 duration-200 zen-mode-macos:ml-margin-macos-traffic-light-x",
-        shouldShowMeta && "border-b border-border",
+        "relative flex min-w-0 items-center justify-between gap-3 overflow-hidden border-b border-transparent text-lg text-zinc-500 duration-200 zen-mode-macos:ml-margin-macos-traffic-light-x",
+        shouldShowMeta && "border-border",
         className,
       )}
     >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed an issue where scrolling caused the header's bottom border to appear, leading to a slight 1px shift of its content. 

No changes were made for mobile component since the element doesn't show after scrolling.

**Before**
![header-before](https://github.com/user-attachments/assets/636e98ed-9b9e-464c-ab21-307e53e8a85b)

**After**
![header-after](https://github.com/user-attachments/assets/36ed27db-d1d8-464c-8033-eb6c530a1fb0)




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
