### PR TITLE
fix(animation): preserve exit transition for smoother animations

### DIFF
--- a/apps/renderer/src/components/common/Motion.tsx
+++ b/apps/renderer/src/components/common/Motion.tsx
@@ -1,4 +1,4 @@
-import type { MotionProps } from "framer-motion"
+import type { MotionProps, TargetAndTransition } from "framer-motion"
 import { m as M } from "framer-motion"
 import { createElement, forwardRef } from "react"
 
@@ -19,6 +19,7 @@ export const m: typeof M = new Proxy(M, {
         if (props.exit) {
           nextProps.exit = {
             opacity: 0,
+            transition: (props.exit as TargetAndTransition).transition,
           }
         }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Motion component should use transition prop in reduce motion mode,
For example,modal default animation type is 'spring',but the exit animation type should be 'tween'.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
