### PR TITLE
fix: Decode the HTML entity in the title

### DIFF
--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -129,9 +129,10 @@ export function ListItem({
         >
           {entry.entries.title ? (
             <EntryTranslation
-              className={cn("break-all", lineClamp.title)}
+              className={cn("break-all text-sm leading-tight", lineClamp.title)}
               source={entry.entries.title}
               target={translation?.title}
+              isHTML
             />
           ) : (
             <EntryTranslation

--- a/apps/renderer/src/modules/entry-content/components/EntryTitle.tsx
+++ b/apps/renderer/src/modules/entry-content/components/EntryTitle.tsx
@@ -92,12 +92,13 @@ export const EntryTitle = ({ entryId, compact }: EntryLinkProps) => {
         }
       }}
     >
-      <div className={cn("select-text break-words font-bold", compact ? "text-2xl" : "text-3xl")}>
+      <div className="select-text break-words font-bold">
         <EntryTranslation
           showTranslation={showAITranslation}
           source={entry.entries.title}
           target={translation.data?.title}
-          className="select-text"
+          className={cn("select-text", compact ? "text-2xl" : "text-3xl")}
+          isHTML
         />
       </div>
       <div className="mt-2 text-[13px] font-medium text-zinc-500">


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Some english feeds has html entity in title.It should be decode
`The Steam Winter Sale includes some of 2024&#8217;s best games` to
`The Steam Winter Sale includes some of 2024's best games`

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
