### PR TITLE
fix: clicking a media should mark the social media item as read

### DIFF
--- a/apps/renderer/src/modules/entry-column/Items/social-media-item.tsx
+++ b/apps/renderer/src/modules/entry-column/Items/social-media-item.tsx
@@ -286,8 +286,7 @@ const SocialMediaGallery = ({ media }: { media: MediaModel[] }) => {
               className="size-28 shrink-0 data-[state=loading]:!bg-theme-placeholder-image"
               loading="lazy"
               proxy={proxySize}
-              onClick={(e) => {
-                e.stopPropagation()
+              onClick={() => {
                 previewMedia(
                   mediaList.map((m) => ({
                     url: m.url,
@@ -337,8 +336,7 @@ const SocialMediaGallery = ({ media }: { media: MediaModel[] }) => {
               className="aspect-square w-full rounded object-cover"
               loading="lazy"
               proxy={proxySize}
-              onClick={(e) => {
-                e.stopPropagation()
+              onClick={() => {
                 previewMedia(
                   media.map((m) => ({
                     url: m.url,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Additional context

This PR removes the `e.stopPropagation()` for the `Media` in social media items to allow items to be selected and marked as read when clicking the media, same as clicking other parts of the item.

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
