### PR TITLE
fix(lists): duplicate addition issue in manage feeds functionality

### DIFF
--- a/apps/renderer/src/modules/settings/tabs/lists/modals.tsx
+++ b/apps/renderer/src/modules/settings/tabs/lists/modals.tsx
@@ -214,9 +214,11 @@ export const ListFeedsModalContent = ({ id }: { id: string }) => {
   const { t } = useTranslation("settings")
 
   const [feedSearchFor, setFeedSearchFor] = useState("")
+  const selectedFeedIdRef = useRef<string | null>()
   const addMutation = useAddFeedToFeedList({
     onSuccess: () => {
       setFeedSearchFor("")
+      selectedFeedIdRef.current = null
     },
   })
 
@@ -230,7 +232,6 @@ export const ListFeedsModalContent = ({ id }: { id: string }) => {
       }))
   }, [allFeeds, list?.feedIds])
 
-  const selectedFeedIdRef = useRef<string | null>()
   if (!list) return null
   return (
     <>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
In Preferences > Lists > Manage Feeds, after adding a new feed, the add button can still be operated to add it again. 
<img width="1205" alt="image" src="https://github.com/user-attachments/assets/6b9b247b-18f3-4068-89b8-6f0431f80f17" />


### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
