### PR TITLE
refactor: migrate context menu to zeego/context-menu

### DIFF
--- a/apps/mobile/src/components/ui/context-menu/index.ios.tsx
+++ b/apps/mobile/src/components/ui/context-menu/index.ios.tsx
@@ -10,6 +10,9 @@ import { useColor } from "@/src/theme/colors"
 
 import type { ContextMenuProps, IContextMenuItemConfig } from "./types"
 
+/**
+ * @deprecated Use `zeego/context-menu` instead
+ */
 export const ContextMenu: FC<ContextMenuProps & PropsWithChildren> = ({
   config,
   onPressMenuItem,

--- a/apps/mobile/src/modules/context-menu/lists.tsx
+++ b/apps/mobile/src/modules/context-menu/lists.tsx
@@ -1,20 +1,14 @@
 import type { FC, PropsWithChildren } from "react"
 import { useMemo } from "react"
 import { Alert, Clipboard } from "react-native"
+import * as ContextMenu from "zeego/context-menu"
 
-import { ContextMenu } from "@/src/components/ui/context-menu"
-import type { NullableContextMenuItemConfig } from "@/src/components/ui/context-menu/types"
 import { getWebUrl } from "@/src/lib/env"
 import { toast } from "@/src/lib/toast"
 import { getList } from "@/src/store/list/getters"
 import { useIsOwnList } from "@/src/store/list/hooks"
 import { subscriptionSyncService } from "@/src/store/subscription/store"
 
-enum ListItemActionKey {
-  EDIT = "edit",
-  COPY_LINK = "copyLink",
-  UNSUBSCRIBE = "unsubscribe",
-}
 export const SubscriptionListItemContextMenu: FC<
   PropsWithChildren & {
     id: string
@@ -22,59 +16,66 @@ export const SubscriptionListItemContextMenu: FC<
 > = ({ id, children }) => {
   const isOwnList = useIsOwnList(id)
   const actions = useMemo(
-    (): NullableContextMenuItemConfig[] => [
+    () => [
       isOwnList && {
         title: "Edit",
-        actionKey: ListItemActionKey.EDIT,
+        onSelect: () => {
+          const list = getList(id)
+          if (!list) return
+          // TODO
+        },
       },
       {
         title: "Copy Link",
-        actionKey: ListItemActionKey.COPY_LINK,
+        onSelect: () => {
+          const list = getList(id)
+          if (!list) return
+          toast.info("Link copied to clipboard")
+          Clipboard.setString(`${getWebUrl()}/share/lists/${list.id}`)
+        },
       },
       {
         title: "Unsubscribe",
-        actionKey: ListItemActionKey.UNSUBSCRIBE,
         destructive: true,
+        onSelect: () => {
+          Alert.alert("Unsubscribe", "Are you sure you want to unsubscribe?", [
+            {
+              text: "Cancel",
+              style: "cancel",
+            },
+            {
+              text: "Unsubscribe",
+              style: "destructive",
+              onPress: () => {
+                subscriptionSyncService.unsubscribe(id)
+              },
+            },
+          ])
+        },
       },
     ],
-    [isOwnList],
+    [id, isOwnList],
   )
+
   return (
-    <ContextMenu
-      config={{ items: actions }}
-      onPressMenuItem={(item) => {
-        switch (item.actionKey) {
-          case ListItemActionKey.EDIT: {
-            // TODO: implement
-            break
-          }
-          case ListItemActionKey.COPY_LINK: {
-            const list = getList(id)
-            if (!list) return
-            toast.info("Link copied to clipboard")
-            Clipboard.setString(`${getWebUrl()}/share/lists/${list.id}`)
-            break
-          }
-          case ListItemActionKey.UNSUBSCRIBE: {
-            Alert.alert("Unsubscribe", "Are you sure you want to unsubscribe?", [
-              {
-                text: "Cancel",
-                style: "cancel",
-              },
-              {
-                text: "Unsubscribe",
-                style: "destructive",
-                onPress: () => {
-                  subscriptionSyncService.unsubscribe(id)
-                },
-              },
-            ])
-            break
-          }
-        }
-      }}
-    >
-      {children}
-    </ContextMenu>
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{children}</ContextMenu.Trigger>
+
+      <ContextMenu.Content>
+        {actions
+          .filter((i) => !!i)
+          .map((action) => {
+            return (
+              <ContextMenu.Item
+                key={action.title}
+                destructive={action.destructive}
+                onSelect={action.onSelect}
+              >
+                <ContextMenu.ItemTitle>{action.title}</ContextMenu.ItemTitle>
+              </ContextMenu.Item>
+            )
+          })}
+      </ContextMenu.Content>
+    </ContextMenu.Root>
   )
 }

--- a/apps/mobile/src/modules/login/index.tsx
+++ b/apps/mobile/src/modules/login/index.tsx
@@ -1,4 +1,3 @@
-import { noop } from "es-toolkit/compat"
 import { router } from "expo-router"
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from "react"
 import { TouchableWithoutFeedback, View } from "react-native"
@@ -10,9 +9,9 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated"
+import * as ContextMenu from "zeego/context-menu"
 
 import { ThemedText } from "@/src/components/common/ThemedText"
-import { ContextMenu } from "@/src/components/ui/context-menu"
 import { Logo } from "@/src/components/ui/logo"
 import {
   LoginTeamsCheckedContext,
@@ -125,22 +124,26 @@ const TeamsCheckBox = forwardRef<
 
 const TeamsText = () => {
   return (
-    <ContextMenu
-      className="overflow-hidden rounded-full px-2"
-      config={{ items: [] }}
-      onPressMenuItem={noop}
-      onPressPreview={() => {
-        router.push("/terms")
-      }}
-      renderPreview={() => (
-        <View className="flex-1">
-          <TeamsMarkdown />
-        </View>
-      )}
-    >
-      <ThemedText className="text-secondary-label text-sm">
-        I agree to the Terms of Service and Privacy Policy
-      </ThemedText>
-    </ContextMenu>
+    <ContextMenu.Root>
+      <ContextMenu.Trigger className="overflow-hidden rounded-full px-2">
+        <ThemedText className="text-secondary-label text-sm">
+          I agree to the Terms of Service and Privacy Policy
+        </ThemedText>
+      </ContextMenu.Trigger>
+
+      <ContextMenu.Content>
+        <ContextMenu.Preview
+          onPress={useCallback(() => {
+            router.push("/terms")
+          }, [])}
+        >
+          {() => (
+            <View className="flex-1">
+              <TeamsMarkdown />
+            </View>
+          )}
+        </ContextMenu.Preview>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
   )
 }

--- a/apps/mobile/src/modules/subscription/ViewTab.tsx
+++ b/apps/mobile/src/modules/subscription/ViewTab.tsx
@@ -7,11 +7,9 @@ import type { WithSpringConfig } from "react-native-reanimated"
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated"
 
 import { ThemedBlurView } from "@/src/components/common/ThemedBlurView"
-import { ContextMenu } from "@/src/components/ui/context-menu"
 import type { ViewDefinition } from "@/src/constants/views"
 import { views } from "@/src/constants/views"
 import { useUnreadCountByView } from "@/src/store/unread/hooks"
-import { unreadSyncService } from "@/src/store/unread/store"
 
 import { offsetAtom, setCurrentView, viewAtom } from "./atoms"
 import { ViewTabHeight } from "./constants"
@@ -113,47 +111,32 @@ const TabItem = memo(
   ({
     isSelected,
     view,
-    onLayout,
   }: { isSelected: boolean; view: ViewDefinition } & Pick<TouchableOpacityProps, "onLayout">) => {
     const unreadCount = useUnreadCountByView(view.view)
     return (
-      <ContextMenu
-        // actions={[{ title: "Mark all as read" }]}
-        config={{ items: [{ title: "Mark all as read", actionKey: "markAllAsRead" }] }}
-        onPressMenuItem={(e) => {
-          switch (e.actionKey) {
-            case "markAllAsRead": {
-              unreadSyncService.markViewAsRead(view.view)
-              break
-            }
-          }
-        }}
-        onLayout={onLayout}
+      <TouchableOpacity
+        activeOpacity={1}
+        onPress={() => setCurrentView(view.view)}
+        className="relative mr-4 flex-row items-center justify-center rounded-full"
       >
-        <TouchableOpacity
-          activeOpacity={1}
-          onPress={() => setCurrentView(view.view)}
-          className="relative mr-4 flex-row items-center justify-center rounded-full"
+        <view.icon color={isSelected ? view.activeColor : "gray"} height={18} width={18} />
+        <Text
+          style={{
+            color: isSelected ? view.activeColor : "gray",
+            fontWeight: isSelected ? "medium" : "normal",
+          }}
+          className="ml-2"
         >
-          <view.icon color={isSelected ? view.activeColor : "gray"} height={18} width={18} />
-          <Text
-            style={{
-              color: isSelected ? view.activeColor : "gray",
-              fontWeight: isSelected ? "medium" : "normal",
-            }}
-            className="ml-2"
-          >
-            {view.name}
-          </Text>
-          {unreadCount > 0 && (
-            <View className={"bg-red ml-1 rounded-full px-1"}>
-              <Text className="text-xs font-medium text-white">
-                {unreadCount > 99 ? "99+" : unreadCount}
-              </Text>
-            </View>
-          )}
-        </TouchableOpacity>
-      </ContextMenu>
+          {view.name}
+        </Text>
+        {unreadCount > 0 && (
+          <View className={"bg-red ml-1 rounded-full px-1"}>
+            <Text className="text-xs font-medium text-white">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </Text>
+          </View>
+        )}
+      </TouchableOpacity>
     )
   },
 )


### PR DESCRIPTION
Refactor the context menu implementation to use the `zeego/context-menu` package, updating all relevant usages throughout the application.

This change enhances maintainability and aligns with the latest library standards.