### PR TITLE
fix(mobile): context menu crash when released too quickly

### DIFF
--- a/apps/mobile/src/components/ui/pressable/item-pressable.tsx
+++ b/apps/mobile/src/components/ui/pressable/item-pressable.tsx
@@ -49,6 +49,10 @@ export const ItemPressable: typeof Pressable = memo(({ children, ...props }) => 
       onPressOut={composeEventHandlers(props.onPressOut, () => setIsPressing(false))}
       onHoverIn={composeEventHandlers(props.onHoverIn, () => setIsPressing(true))}
       onHoverOut={composeEventHandlers(props.onHoverOut, () => setIsPressing(false))}
+      // This is a workaround to prevent context menu crash when release too quickly
+      // https://github.com/nandorojo/zeego/issues/61
+      onLongPress={composeEventHandlers(props.onLongPress, () => {})}
+      delayLongPress={props.delayLongPress ?? 100}
       className={cn(props.className, "bg-secondary-system-background relative")}
       style={props.style}
     >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

- https://github.com/nandorojo/zeego/issues/61
- https://github.com/dominicstop/react-native-ios-context-menu/issues/9

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
