### PR TITLE
feat(window): add alwaysOnTop property in createWindow function

### DIFF
--- a/apps/main/src/window.ts
+++ b/apps/main/src/window.ts
@@ -41,6 +41,7 @@ export function createWindow(
     show: false,
     resizable: configs?.resizable ?? true,
     autoHideMenuBar: true,
+    alwaysOnTop: false,
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.mjs"),
       sandbox: false,


### PR DESCRIPTION
### Description

Fixed a bug where the Follow window was always staying on top of other windows, which affected normal window management and user experience.

### PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Hotfix
- [ ] Other (please describe):

### Additional context

This fix ensures the Follow window follows normal window layering behavior.

### Changelog

- [x] I have updated the changelog/next.md with my changes.
