### PR TITLE
refactor: update app activation event handling in Electron

### DIFF
--- a/apps/main/src/index.ts
+++ b/apps/main/src/index.ts
@@ -59,6 +59,13 @@ function bootstrap() {
     }
   })
 
+  app.on("activate", () => {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    mainWindow = getMainWindowOrCreate()
+    mainWindow.show()
+  })
+
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
@@ -157,13 +164,6 @@ function bootstrap() {
         callback({ cancel: false, responseHeaders })
       },
     )
-
-    app.on("activate", () => {
-      // On macOS it's common to re-create a window in the app when the
-      // dock icon is clicked and there are no other windows open.
-      mainWindow = getMainWindowOrCreate()
-      mainWindow.show()
-    })
 
     app.on("open-url", (_, url) => {
       if (mainWindow && !mainWindow.isDestroyed()) {


### PR DESCRIPTION
### Description

Fixed a bug where the Follow window could not be reopened by clicking the Dock icon after closing it with CMD+W. This improves the macOS user experience by ensuring standard window management behavior.

### PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Hotfix
- [ ] Other (please describe):

### Additional context

This fix restores the expected macOS window management behavior where clicking the Dock icon should reopen a closed window.

### Changelog

- [x] I have updated the changelog/next.md with my changes.
