### PR TITLE
fix: make icon center when media has play status

### DIFF
--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -281,7 +281,7 @@ function AudioCover({
       <div
         className={cn(
           "center absolute inset-0 w-full transition-all duration-200 ease-in-out group-hover:-translate-y-2 group-hover:opacity-100",
-          playStatus ? "opacity-100" : "opacity-0",
+          playStatus ? "-translate-y-2 opacity-100" : "opacity-0",
           isMobile && "-translate-y-2 opacity-100",
         )}
         onClick={handleClickPlay}

--- a/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
+++ b/apps/renderer/src/modules/entry-column/templates/list-item-template.tsx
@@ -281,8 +281,7 @@ function AudioCover({
       <div
         className={cn(
           "center absolute inset-0 w-full transition-all duration-200 ease-in-out group-hover:-translate-y-2 group-hover:opacity-100",
-          playStatus ? "-translate-y-2 opacity-100" : "opacity-0",
-          isMobile && "-translate-y-2 opacity-100",
+          playStatus || isMobile ? "-translate-y-2 opacity-100" : "opacity-0",
         )}
         onClick={handleClickPlay}
       >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

Before:

![CleanShot 2025-02-27 at 09 33 44](https://github.com/user-attachments/assets/f5a8b1a5-cf08-457b-a89d-38892cdf3dcb)


After:

![CleanShot 2025-02-27 at 09 33 34](https://github.com/user-attachments/assets/40b47590-8e58-421d-ad20-f7bf1dddc60b)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
