### PR TITLE
feat(mobile): add deep link redirection to follow screen

### DIFF
--- a/apps/mobile/src/components/common/ModalSharedComponents.tsx
+++ b/apps/mobile/src/components/common/ModalSharedComponents.tsx
@@ -1,6 +1,6 @@
 import { withOpacity } from "@follow/utils"
 import { router } from "expo-router"
-import { useMemo } from "react"
+import { useCallback,useMemo  } from "react"
 import { TouchableOpacity } from "react-native"
 
 import { useIsRouteOnlyOne } from "@/src/hooks/useIsRouteOnlyOne"
@@ -21,8 +21,17 @@ const ModalHeaderCloseButtonImpl = () => {
   const routeOnlyOne = useIsRouteOnlyOne()
   const memoedRouteOnlyOne = useMemo(() => routeOnlyOne, [])
 
+  const handlePress = useCallback(() => {
+    if (router.canDismiss()) {
+      router.dismiss()
+    } else {
+      // If we can't dismiss, redirect to the root route
+      router.replace("/")
+    }
+  }, [])
+
   return (
-    <TouchableOpacity onPress={() => router.dismiss()}>
+    <TouchableOpacity onPress={handlePress}>
       {memoedRouteOnlyOne ? (
         <CloseCuteReIcon height={20} width={20} color={label} />
       ) : (

--- a/apps/mobile/src/components/common/ModalSharedComponents.tsx
+++ b/apps/mobile/src/components/common/ModalSharedComponents.tsx
@@ -1,6 +1,6 @@
 import { withOpacity } from "@follow/utils"
 import { router } from "expo-router"
-import { useCallback,useMemo  } from "react"
+import { useCallback, useMemo } from "react"
 import { TouchableOpacity } from "react-native"
 
 import { useIsRouteOnlyOne } from "@/src/hooks/useIsRouteOnlyOne"

--- a/apps/mobile/src/modules/feed/FollowFeed.tsx
+++ b/apps/mobile/src/modules/feed/FollowFeed.tsx
@@ -104,6 +104,9 @@ function FollowImpl(props: { feedId: string }) {
       if (!routeOnlyOne) {
         parentRoute?.dispatch(StackActions.popToTop())
       }
+    } else {
+      // If we can't dismiss, redirect to the root route
+      router.replace("/")
     }
   }
 

--- a/apps/mobile/src/screens/+native-intent.tsx
+++ b/apps/mobile/src/screens/+native-intent.tsx
@@ -1,0 +1,23 @@
+// Redirects to the home screen when the app is opened with a deep link.
+// Test this by running the following command in the terminal:
+// pnpx uri-scheme open 'follow://add?id=1' --ios
+//
+// See https://docs.expo.dev/router/advanced/native-intent/#rewrite-incoming-native-deep-links
+
+export function redirectSystemPath(_options: { path: string; initial: boolean }) {
+  const { path } = _options
+  if (!_options.path) return
+  const parsedUrl = parseUrl(path)
+  if (!parsedUrl) return
+  const id = parsedUrl.searchParams.get("id")
+  if (!id) return
+  return `/follow?id=${id}`
+}
+
+const parseUrl = (url: string) => {
+  try {
+    return new URL(url)
+  } catch {
+    return
+  }
+}


### PR DESCRIPTION
Resolve FOL-1681

Implement deep link handling to redirect users to the follow screen when the app is opened with a specific URI scheme.

https://github.com/user-attachments/assets/8b30c04b-cf54-42a9-9e04-b5855b314182

