### PR TITLE
feat(mobile): add option to open videos in external apps

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -41,6 +41,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       LSApplicationCategoryType: "public.app-category.news",
       ITSAppUsesNonExemptEncryption: false,
       UIBackgroundModes: ["audio"],
+      LSApplicationQueriesSchemes: ["bilibili", "youtube"],
     },
     googleServicesFile: "./build/GoogleService-Info.plist",
   },

--- a/apps/mobile/src/atoms/settings/general.ts
+++ b/apps/mobile/src/atoms/settings/general.ts
@@ -28,6 +28,9 @@ const createDefaultSettings = (): GeneralSettings => ({
   jumpOutLinkWarn: true,
   // TTS
   voice: "en-US-AndrewMultilingualNeural",
+
+  // Video
+  openVideoInApp: true,
 })
 
 export const {

--- a/apps/mobile/src/interfaces/settings/general.ts
+++ b/apps/mobile/src/interfaces/settings/general.ts
@@ -17,4 +17,9 @@ export interface GeneralSettings {
    * Auto expand long social media
    */
   autoExpandLongSocialMedia: boolean
+
+  /**
+   * Open YouTube/Bilibili videos in their respective apps rather than in-app browser
+   */
+  openVideoInApp: boolean
 }

--- a/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
+++ b/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
@@ -1,8 +1,8 @@
-import { transformVideoUrl } from "@follow/utils"
+import { openVideo } from "@follow/utils"
 
+import { useGeneralSettingKey } from "@/src/atoms/settings/general"
 import { MediaCarousel } from "@/src/components/ui/carousel/MediaCarousel"
 import { ItemPressable } from "@/src/components/ui/pressable/ItemPressable"
-import { openLink } from "@/src/lib/native"
 import { useEntry } from "@/src/store/entry/hooks"
 import { unreadSyncService } from "@/src/store/unread/store"
 
@@ -10,27 +10,27 @@ import { VideoContextMenu } from "../../context-menu/video"
 
 export function EntryVideoItem({ id }: { id: string }) {
   const item = useEntry(id)
+  const needOpenVideoInApp = useGeneralSettingKey("openVideoInApp")
 
   if (!item || !item.media) {
     return null
   }
 
-  const firstMedia = item.media[0]!
+  const firstMedia = item.media.slice(0, 1)
 
   return (
     <VideoContextMenu entryId={id}>
       <ItemPressable
         className="m-1 overflow-hidden rounded-md"
-        onPress={() => {
+        onPress={async () => {
           unreadSyncService.markEntryAsRead(id)
           if (!item.url) return
-          const formattedUrl = transformVideoUrl({ url: item.url }) || item.url
-          openLink(formattedUrl)
+          openVideo(item.url, needOpenVideoInApp)
         }}
       >
         <MediaCarousel
           entryId={id}
-          media={[firstMedia]}
+          media={firstMedia}
           aspectRatio={16 / 9}
           AccessoryProps={{ id }}
           noPreview={true}

--- a/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
+++ b/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
@@ -1,5 +1,5 @@
 import { transformVideoUrl } from "@follow/utils"
-import * as Linking from "expo-linking"
+import { Linking } from "react-native"
 
 import { useGeneralSettingKey } from "@/src/atoms/settings/general"
 import { MediaCarousel } from "@/src/components/ui/carousel/MediaCarousel"
@@ -74,10 +74,14 @@ const parseSchemeLink = (url: string) => {
 const openVideo = async (url: string, openVideoInApp = false) => {
   if (openVideoInApp) {
     const schemeLink = parseSchemeLink(url)
-    const isInstalled = schemeLink && (await Linking.canOpenURL(schemeLink))
-    if (schemeLink && isInstalled) {
-      await Linking.openURL(schemeLink)
-      return
+    try {
+      const isInstalled = !!schemeLink && (await Linking.canOpenURL(schemeLink))
+      if (schemeLink && isInstalled) {
+        await Linking.openURL(schemeLink)
+        return
+      }
+    } catch {
+      // Ignore error
     }
   }
 

--- a/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
+++ b/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
@@ -47,8 +47,13 @@ export function EntryVideoItem({ id }: { id: string }) {
 }
 
 const parseSchemeLink = (url: string) => {
-  if (!URL.canParse(url)) return null
-  const urlObject = new URL(url)
+  let urlObject: URL
+  try {
+    urlObject = new URL(url)
+  } catch {
+    return null
+  }
+
   switch (urlObject.hostname) {
     case "www.bilibili.com": {
       // bilibili://video/{av}or{bv}

--- a/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
+++ b/apps/mobile/src/modules/entry-list/templates/EntryVideoItem.tsx
@@ -3,6 +3,7 @@ import { openVideo } from "@follow/utils"
 import { useGeneralSettingKey } from "@/src/atoms/settings/general"
 import { MediaCarousel } from "@/src/components/ui/carousel/MediaCarousel"
 import { ItemPressable } from "@/src/components/ui/pressable/ItemPressable"
+import { toast } from "@/src/lib/toast"
 import { useEntry } from "@/src/store/entry/hooks"
 import { unreadSyncService } from "@/src/store/unread/store"
 
@@ -22,9 +23,12 @@ export function EntryVideoItem({ id }: { id: string }) {
     <VideoContextMenu entryId={id}>
       <ItemPressable
         className="m-1 overflow-hidden rounded-md"
-        onPress={async () => {
+        onPress={() => {
           unreadSyncService.markEntryAsRead(id)
-          if (!item.url) return
+          if (!item.url) {
+            toast.error("No video URL found")
+            return
+          }
           openVideo(item.url, needOpenVideoInApp)
         }}
       >

--- a/apps/mobile/src/modules/settings/routes/General.tsx
+++ b/apps/mobile/src/modules/settings/routes/General.tsx
@@ -25,6 +25,7 @@ export const GeneralScreen = () => {
   const expandLongSocialMedia = useGeneralSettingKey("autoExpandLongSocialMedia")
   const markAsReadWhenScrolling = useGeneralSettingKey("scrollMarkUnread")
   const markAsReadWhenInView = useGeneralSettingKey("renderMarkUnread")
+  const openVideoInApp = useGeneralSettingKey("openVideoInApp")
 
   return (
     <SafeNavigationScrollView className="bg-system-grouped-background">
@@ -138,6 +139,25 @@ export const GeneralScreen = () => {
                 value={markAsReadWhenInView}
                 onValueChange={(value) => {
                   setGeneralSetting("renderMarkUnread", value)
+                }}
+              />
+            </GroupedInsetListCell>
+          </GroupedInsetListCard>
+        </View>
+
+        {/* Content Behavior */}
+        <View className="mt-8">
+          <GroupedInsetListSectionHeader label="Video" />
+          <GroupedInsetListCard>
+            <GroupedInsetListCell
+              label="Open videos in app"
+              description="Open videos in their respective apps, if available, instead of the in-app browser."
+            >
+              <Switch
+                size="sm"
+                value={openVideoInApp}
+                onValueChange={(value) => {
+                  setGeneralSetting("openVideoInApp", value)
                 }}
               />
             </GroupedInsetListCell>

--- a/packages/utils/src/url-for-video.ts
+++ b/packages/utils/src/url-for-video.ts
@@ -1,7 +1,3 @@
-import * as Linking from "expo-linking"
-
-import { openLink } from "@/src/lib/native"
-
 export const transformVideoUrl = ({
   url,
   mini = false,
@@ -46,39 +42,4 @@ export const transformVideoUrl = ({
     return attachments.find((attachment) => attachment.mime_type === "text/html")?.url ?? null
   }
   return null
-}
-
-const parseSchemeLink = (url: string) => {
-  if (!URL.canParse(url)) return null
-  const urlObject = new URL(url)
-  switch (urlObject.hostname) {
-    case "www.bilibili.com": {
-      // bilibili://video/{av}or{bv}
-      const bvid = urlObject.pathname.match(/video\/(BV\w+)/)?.[1]
-      return bvid ? `bilibili://video/${bvid}` : null
-    }
-    case "www.youtube.com": {
-      // youtube://watch?v=xxx
-      const videoId = urlObject.searchParams.get("v")
-      return videoId ? `youtube://watch?v=${videoId}` : null
-    }
-    default: {
-      return null
-    }
-  }
-}
-
-export const openVideo = async (url: string, openVideoInApp = false) => {
-  if (openVideoInApp) {
-    const schemeLink = parseSchemeLink(url)
-    const isInstalled = schemeLink && (await Linking.canOpenURL(schemeLink))
-    if (schemeLink && isInstalled) {
-      await Linking.openURL(schemeLink)
-      return
-    }
-  }
-
-  // Fallback to opening in in-app browser
-  const formattedUrl = transformVideoUrl({ url }) || url
-  openLink(formattedUrl)
 }


### PR DESCRIPTION
Resolves FOL-1679

Introduce a setting to allow users to open YouTube and Bilibili videos in their respective apps instead of the in-app browser. This includes updates to settings management and video handling logic.