### PR TITLE
feat(desktop): hide separator when availableActions is empty

### DIFF
--- a/apps/desktop/src/renderer/src/modules/command/hooks/use-command.ts
+++ b/apps/desktop/src/renderer/src/modules/command/hooks/use-command.ts
@@ -6,6 +6,11 @@ import { useCallback, useMemo } from "react"
 import { CommandRegistry } from "../registry/registry"
 import type { FollowCommandId, FollowCommandMap } from "../types"
 
+export const hasCommand = <T extends FollowCommandId>(id: T) => {
+  const commands = jotaiStore.get(CommandRegistry.atom) as FollowCommandMap
+  return id in commands
+}
+
 export const getCommand = <T extends FollowCommandId>(id: T) => {
   const commands = jotaiStore.get(CommandRegistry.atom) as FollowCommandMap
   return id in commands ? commands[id] : null

--- a/apps/desktop/src/renderer/src/modules/entry-content/actions/more-actions.tsx
+++ b/apps/desktop/src/renderer/src/modules/entry-content/actions/more-actions.tsx
@@ -11,11 +11,17 @@ import {
 } from "~/components/ui/dropdown-menu/dropdown-menu"
 import { useSortedEntryActions } from "~/hooks/biz/useEntryActions"
 import { COMMAND_ID } from "~/modules/command/commands/id"
-import { useCommand } from "~/modules/command/hooks/use-command"
+import { hasCommand, useCommand } from "~/modules/command/hooks/use-command"
 import type { FollowCommandId } from "~/modules/command/types"
 
 export const MoreActions = ({ entryId, view }: { entryId: string; view?: FeedViewType }) => {
-  const { moreAction: actionConfigs } = useSortedEntryActions({ entryId, view })
+  const { moreAction } = useSortedEntryActions({ entryId, view })
+
+  const actionConfigs = useMemo(
+    () => moreAction.filter((action) => hasCommand(action.id)),
+    [moreAction],
+  )
+
   const availableActions = useMemo(
     () => actionConfigs.filter((item) => item.id !== COMMAND_ID.settings.customizeToolbar),
     [actionConfigs],
@@ -26,7 +32,7 @@ export const MoreActions = ({ entryId, view }: { entryId: string; view?: FeedVie
     [actionConfigs],
   )
 
-  if (availableActions.length === 0) {
+  if (availableActions.length === 0 && extraAction.length === 0) {
     return null
   }
 
@@ -44,7 +50,7 @@ export const MoreActions = ({ entryId, view }: { entryId: string; view?: FeedVie
             active={config.active}
           />
         ))}
-        <DropdownMenuSeparator />
+        {availableActions.length > 0 && <DropdownMenuSeparator />}
         {extraAction.map((config) => (
           <CommandDropdownMenuItem
             key={config.id}


### PR DESCRIPTION
Before:
![CleanShot 2025-03-13 at 08 47 57](https://github.com/user-attachments/assets/5161745a-df19-4a68-8a92-1d08152a810b)

After:
![CleanShot 2025-03-13 at 09 04 06](https://github.com/user-attachments/assets/ae478bab-c1f3-43a5-b077-e61ed79b0f8f)
