### PR TITLE
feat(mobile): implement language-based preset feeds for onboarding

### DIFF
--- a/apps/mobile/src/modules/onboarding/feeds-english.json
+++ b/apps/mobile/src/modules/onboarding/feeds-english.json
@@ -1,6 +1,6 @@
 [
   {
-    "feedId": "43255084704601096",
+    "feedId": "43255084704601095",
     "title": "a16z Podcast",
     "url": "https://feeds.simplecast.com/JGE3yC0V",
     "language": "English"
@@ -13,93 +13,93 @@
     "view": 3
   },
   {
-    "feedId": "62128288597853190",
+    "feedId": "62128288597853189",
     "title": "Cal Newport",
     "url": "https://calnewport.com/feed/",
     "language": "English"
   },
   {
-    "feedId": "43881675446885380",
+    "feedId": "43881675446885376",
     "title": "Collab Fund",
     "url": "http://feeds.feedburner.com/collabfund",
     "language": "English"
   },
   {
-    "feedId": "41359648684677176",
+    "feedId": "41359648684677175",
     "title": "Derek Sivers blog",
     "url": "https://sive.rs/en.atom",
     "language": "English"
   },
   {
-    "feedId": "52325519371718660",
+    "feedId": "52325519371718656",
     "title": "Hacker News",
     "url": "rsshub://hackernews",
     "language": "English"
   },
   {
-    "feedId": "41381007770949630",
+    "feedId": "41381007770949636",
     "title": "IGN Articles",
     "url": "https://www.ign.com/rss/articles/feed?tags=games",
     "language": "English"
   },
   {
-    "feedId": "59461847827447810",
+    "feedId": "59461847827447808",
     "title": "International homepage",
     "url": "https://www.ft.com/rss/home",
     "language": "English"
   },
   {
-    "feedId": "52333046926856210",
+    "feedId": "52333046926856207",
     "title": "Kotaku",
     "url": "https://kotaku.com/rss",
     "language": "English"
   },
   {
-    "feedId": "41768239731545100",
+    "feedId": "41768239731545104",
     "title": "LessWrong",
     "url": "https://www.lesswrong.com/feed.xml?view=curated-rss",
     "language": "English"
   },
   {
-    "feedId": "41375850878492670",
+    "feedId": "41375850878492672",
     "title": "Lex Fridman - YouTube",
     "url": "rsshub://youtube/user/%40lexfridman",
     "language": "English",
     "view": 3
   },
   {
-    "feedId": "55258726035912720",
+    "feedId": "55258726035912721",
     "title": "Marginal REVOLUTION",
     "url": "https://marginalrevolution.com/feed",
     "language": "English"
   },
   {
-    "feedId": "42109057149046780",
+    "feedId": "42109057149046784",
     "title": "Marques Brownlee - YouTube",
     "url": "rsshub://youtube/user/@mkbhd",
     "language": "English",
     "view": 3
   },
   {
-    "feedId": "41768239731545090",
+    "feedId": "41768239731545089",
     "title": "MIT Technology Review",
     "url": "https://www.technologyreview.com/feed/",
     "language": "English"
   },
   {
-    "feedId": "42127302309630070",
+    "feedId": "42127302309630072",
     "title": "Mr. Money Mustache",
     "url": "https://feeds.feedburner.com/mrmoneymustache",
     "language": "English"
   },
   {
-    "feedId": "41356263889737730",
+    "feedId": "41356263889737728",
     "title": "NASA Astronomy Picture of the Day",
     "url": "rsshub://nasa/apod",
     "language": "English"
   },
   {
-    "feedId": "55130722692595736",
+    "feedId": "55130722692595739",
     "title": "Nassim Taleb",
     "url": "https://nassimtaleb.org/feed/",
     "language": "English"
@@ -111,7 +111,7 @@
     "language": "English"
   },
   {
-    "feedId": "42127302309630020",
+    "feedId": "42127302309630013",
     "title": "Nautilus",
     "url": "https://nautil.us/feed/",
     "language": "English"
@@ -123,7 +123,7 @@
     "language": "English"
   },
   {
-    "feedId": "41468521403732990",
+    "feedId": "41468521403732992",
     "title": "Paul Graham - Essays",
     "url": "rsshub://paulgraham/articles",
     "language": "English"
@@ -135,80 +135,80 @@
     "language": "English"
   },
   {
-    "feedId": "41382261184290820",
+    "feedId": "41382261184290816",
     "title": "Product Hunt — The best new products, every day",
     "url": "https://www.producthunt.com/feed",
     "language": "English"
   },
   {
-    "feedId": "43254816999905280",
+    "feedId": "43254816999905282",
     "title": "Research & Insights",
     "url": "https://www.bridgewater.com/research-and-insights.rss",
     "language": "English"
   },
   {
-    "feedId": "41147805276726400",
+    "feedId": "41147805276726402",
     "title": "RSSHub has new routes",
     "url": "rsshub://rsshub/routes",
     "language": "English"
   },
   {
-    "feedId": "66860831563739170",
+    "feedId": "66860831563739166",
     "title": "Sabine Hossenfelder",
     "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UC1yNl2E66ZzKApQdRuTQ4tw",
     "language": "English",
     "view": 3
   },
   {
-    "feedId": "49470377330653210",
+    "feedId": "49470377330653207",
     "title": "Seth's Blog",
     "url": "https://seths.blog/feed/",
     "language": "English"
   },
   {
-    "feedId": "41795937311945740",
+    "feedId": "41795937311945747",
     "title": "Stratechery by Ben Thompson",
     "url": "https://stratechery.com/feed/",
     "language": "English"
   },
   {
-    "feedId": "59299066394742780",
+    "feedId": "59299066394742784",
     "title": "TechCrunch",
     "url": "https://techcrunch.com/feed/",
     "language": "English"
   },
   {
-    "feedId": "49470377330653190",
+    "feedId": "49470377330653193",
     "title": "The Blog of Author Tim Ferriss",
     "url": "https://tim.blog/feed/",
     "language": "English"
   },
   {
-    "feedId": "57993144602143740",
+    "feedId": "57993144602143744",
     "title": "The Memo by Howard Marks",
     "url": "https://rss.art19.com/the-memo-by-howard-marks",
     "language": "English"
   },
   {
-    "feedId": "100080366298125310",
+    "feedId": "100080366298125312",
     "title": "The Verge",
     "url": "https://www.theverge.com/rss/index.xml",
     "language": "English"
   },
   {
-    "feedId": "41572238278099970",
+    "feedId": "41572238278099968",
     "title": "The world in brief | The Economist",
     "url": "rsshub://economist/espresso",
     "language": "English"
   },
   {
-    "feedId": "41368476124603390",
+    "feedId": "41368476124603392",
     "title": "Trending repositories on GitHub this week · GitHub",
     "url": "rsshub://github/trending/weekly/any",
     "language": "English"
   },
   {
-    "feedId": "41461870197170190",
+    "feedId": "41461870197170196",
     "title": "Trending repositories on GitHub today · GitHub",
     "url": "rsshub://github/trending/daily/any",
     "language": "English"
@@ -228,34 +228,34 @@
     "view": 1
   },
   {
-    "feedId": "100411504863520770",
+    "feedId": "100411504863520768",
     "title": "Twitter @Elon Musk",
     "url": "rsshub://twitter/user/elonmusk",
     "language": "English",
     "view": 1
   },
   {
-    "feedId": "41215396143077384",
+    "feedId": "41215396143077382",
     "title": "Twitter @Follow",
     "url": "rsshub://twitter/user/follow_app_",
     "language": "English",
     "view": 1
   },
   {
-    "feedId": "55866936513101820",
+    "feedId": "55866936513101824",
     "title": "Twitter @James Clear",
     "url": "rsshub://twitter/user/JamesClear",
     "language": "English",
     "view": 1
   },
   {
-    "feedId": "41342818712721410",
+    "feedId": "41342818712721408",
     "title": "Wait But Why",
     "url": "https://waitbutwhy.com/feed?code=c6f56c4214621ab98b86acbcae6b4405",
     "language": "English"
   },
   {
-    "feedId": "41965184796582020",
+    "feedId": "41965184796582014",
     "title": "WIRED",
     "url": "https://www.wired.com/feed/rss",
     "language": "English"

--- a/apps/mobile/src/modules/onboarding/feeds-english.json
+++ b/apps/mobile/src/modules/onboarding/feeds-english.json
@@ -1,0 +1,263 @@
+[
+  {
+    "feedId": "43255084704601096",
+    "title": "a16z Podcast",
+    "url": "https://feeds.simplecast.com/JGE3yC0V",
+    "language": "English"
+  },
+  {
+    "feedId": "83007794771225600",
+    "title": "Andrew Huberman - YouTube",
+    "url": "rsshub://youtube/user/@hubermanlab",
+    "language": "English",
+    "view": 3
+  },
+  {
+    "feedId": "62128288597853190",
+    "title": "Cal Newport",
+    "url": "https://calnewport.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "43881675446885380",
+    "title": "Collab Fund",
+    "url": "http://feeds.feedburner.com/collabfund",
+    "language": "English"
+  },
+  {
+    "feedId": "41359648684677176",
+    "title": "Derek Sivers blog",
+    "url": "https://sive.rs/en.atom",
+    "language": "English"
+  },
+  {
+    "feedId": "52325519371718660",
+    "title": "Hacker News",
+    "url": "rsshub://hackernews",
+    "language": "English"
+  },
+  {
+    "feedId": "41381007770949630",
+    "title": "IGN Articles",
+    "url": "https://www.ign.com/rss/articles/feed?tags=games",
+    "language": "English"
+  },
+  {
+    "feedId": "59461847827447810",
+    "title": "International homepage",
+    "url": "https://www.ft.com/rss/home",
+    "language": "English"
+  },
+  {
+    "feedId": "52333046926856210",
+    "title": "Kotaku",
+    "url": "https://kotaku.com/rss",
+    "language": "English"
+  },
+  {
+    "feedId": "41768239731545100",
+    "title": "LessWrong",
+    "url": "https://www.lesswrong.com/feed.xml?view=curated-rss",
+    "language": "English"
+  },
+  {
+    "feedId": "41375850878492670",
+    "title": "Lex Fridman - YouTube",
+    "url": "rsshub://youtube/user/%40lexfridman",
+    "language": "English",
+    "view": 3
+  },
+  {
+    "feedId": "55258726035912720",
+    "title": "Marginal REVOLUTION",
+    "url": "https://marginalrevolution.com/feed",
+    "language": "English"
+  },
+  {
+    "feedId": "42109057149046780",
+    "title": "Marques Brownlee - YouTube",
+    "url": "rsshub://youtube/user/@mkbhd",
+    "language": "English",
+    "view": 3
+  },
+  {
+    "feedId": "41768239731545090",
+    "title": "MIT Technology Review",
+    "url": "https://www.technologyreview.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "42127302309630070",
+    "title": "Mr. Money Mustache",
+    "url": "https://feeds.feedburner.com/mrmoneymustache",
+    "language": "English"
+  },
+  {
+    "feedId": "41356263889737730",
+    "title": "NASA Astronomy Picture of the Day",
+    "url": "rsshub://nasa/apod",
+    "language": "English"
+  },
+  {
+    "feedId": "55130722692595736",
+    "title": "Nassim Taleb",
+    "url": "https://nassimtaleb.org/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "41699925856588800",
+    "title": "Nat Geo Photo of the Day",
+    "url": "rsshub://natgeo/dailyphoto",
+    "language": "English"
+  },
+  {
+    "feedId": "42127302309630020",
+    "title": "Nautilus",
+    "url": "https://nautil.us/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "41147805276726370",
+    "title": "Obsidian Changelog",
+    "url": "https://obsidian.md/changelog.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41468521403732990",
+    "title": "Paul Graham - Essays",
+    "url": "rsshub://paulgraham/articles",
+    "language": "English"
+  },
+  {
+    "feedId": "55130722692595736",
+    "title": "Peter Attia",
+    "url": "https://peterattiamd.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "41382261184290820",
+    "title": "Product Hunt — The best new products, every day",
+    "url": "https://www.producthunt.com/feed",
+    "language": "English"
+  },
+  {
+    "feedId": "43254816999905280",
+    "title": "Research & Insights",
+    "url": "https://www.bridgewater.com/research-and-insights.rss",
+    "language": "English"
+  },
+  {
+    "feedId": "41147805276726400",
+    "title": "RSSHub has new routes",
+    "url": "rsshub://rsshub/routes",
+    "language": "English"
+  },
+  {
+    "feedId": "66860831563739170",
+    "title": "Sabine Hossenfelder",
+    "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UC1yNl2E66ZzKApQdRuTQ4tw",
+    "language": "English",
+    "view": 3
+  },
+  {
+    "feedId": "49470377330653210",
+    "title": "Seth's Blog",
+    "url": "https://seths.blog/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "41795937311945740",
+    "title": "Stratechery by Ben Thompson",
+    "url": "https://stratechery.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "59299066394742780",
+    "title": "TechCrunch",
+    "url": "https://techcrunch.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "49470377330653190",
+    "title": "The Blog of Author Tim Ferriss",
+    "url": "https://tim.blog/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "57993144602143740",
+    "title": "The Memo by Howard Marks",
+    "url": "https://rss.art19.com/the-memo-by-howard-marks",
+    "language": "English"
+  },
+  {
+    "feedId": "100080366298125310",
+    "title": "The Verge",
+    "url": "https://www.theverge.com/rss/index.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41572238278099970",
+    "title": "The world in brief | The Economist",
+    "url": "rsshub://economist/espresso",
+    "language": "English"
+  },
+  {
+    "feedId": "41368476124603390",
+    "title": "Trending repositories on GitHub this week · GitHub",
+    "url": "rsshub://github/trending/weekly/any",
+    "language": "English"
+  },
+  {
+    "feedId": "41461870197170190",
+    "title": "Trending repositories on GitHub today · GitHub",
+    "url": "rsshub://github/trending/daily/any",
+    "language": "English"
+  },
+  {
+    "feedId": "87076619508029440",
+    "title": "Twitter @Balaji",
+    "url": "rsshub://twitter/user/balajis",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "59795737540541440",
+    "title": "Twitter @David Sinclair",
+    "url": "rsshub://twitter/user/davidasinclair",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "100411504863520770",
+    "title": "Twitter @Elon Musk",
+    "url": "rsshub://twitter/user/elonmusk",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "41215396143077384",
+    "title": "Twitter @Follow",
+    "url": "rsshub://twitter/user/follow_app_",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "55866936513101820",
+    "title": "Twitter @James Clear",
+    "url": "rsshub://twitter/user/JamesClear",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "41342818712721410",
+    "title": "Wait But Why",
+    "url": "https://waitbutwhy.com/feed?code=c6f56c4214621ab98b86acbcae6b4405",
+    "language": "English"
+  },
+  {
+    "feedId": "41965184796582020",
+    "title": "WIRED",
+    "url": "https://www.wired.com/feed/rss",
+    "language": "English"
+  }
+]

--- a/apps/mobile/src/modules/onboarding/feeds.json
+++ b/apps/mobile/src/modules/onboarding/feeds.json
@@ -1,0 +1,1438 @@
+[
+  {
+    "feedId": "41358761177015296",
+    "title": "知乎热榜 - 全站",
+    "url": "rsshub://zhihu/hot/total",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805268337669",
+    "title": "V2EX-最热主题",
+    "url": "rsshub://v2ex/topics/hot",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805276726272",
+    "title": "少数派",
+    "url": "rsshub://sspai/index",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41374278075966464",
+    "title": "V2EX-最新主题",
+    "url": "rsshub://v2ex/topics/latest",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "64124473013636098",
+    "title": "Followin",
+    "url": "rsshub://followin/news",
+    "language": "English"
+  },
+  {
+    "feedId": "78806242632741888",
+    "title": "bilibili 排行榜-全站",
+    "url": "rsshub://bilibili/ranking/0",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "41358830592746496",
+    "title": "微博热搜榜",
+    "url": "rsshub://weibo/search/hot",
+    "language": "Chinese",
+    "view": 1
+  },
+  {
+    "feedId": "41719081557593134",
+    "title": "小众软件",
+    "url": "https://feeds.appinn.com/appinns/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41443203209057309",
+    "title": "财新网 - 最新文章",
+    "url": "rsshub://caixin/latest",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100411504863520768",
+    "title": "Twitter @Elon Musk",
+    "url": "rsshub://twitter/user/elonmusk",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "100020530265058357",
+    "title": "阮一峰的网络日志",
+    "url": "https://feeds.feedburner.com/ruanyifeng",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41324816676184077",
+    "title": "Twitter @DIŸgöd ☀️",
+    "url": "rsshub://twitter/user/DIYgod",
+    "language": "Chinese",
+    "view": 1
+  },
+  {
+    "feedId": "41147805276726311",
+    "title": "Twitter @Joshua Meng 🟠",
+    "url": "rsshub://twitter/user/JoshuaRSS3",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "41147805276726275",
+    "title": "潮流周刊",
+    "url": "https://weekly.tw93.fun/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41223694984583170",
+    "title": "Hi, DIYgod",
+    "url": "https://diygod.cc/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56445572623398912",
+    "title": "简书首页",
+    "url": "rsshub://jianshu/home",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "60338304723722240",
+    "title": "实时财经快讯 - FastBull",
+    "url": "rsshub://fastbull/express-news",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55611390687386624",
+    "title": "格隆汇快讯-7x24小时市场快讯-财经市场热点",
+    "url": "rsshub://gelonghui/live",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "49375919416104960",
+    "title": "深潮TechFlow - 快讯",
+    "url": "rsshub://techflowpost/express",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55982073122828305",
+    "title": "TED Talks Daily",
+    "url": "https://feeds.acast.com/public/shows/67587e77c705e441797aff96",
+    "language": "English"
+  },
+  {
+    "feedId": "72541715399995392",
+    "title": "TheBlockBeats - 快讯",
+    "url": "rsshub://theblockbeats/newsflash/0",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100184911354754055",
+    "title": "小Lin说",
+    "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCilwQlk62k1z7aUEZPOB6yw",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100185810923910148",
+    "title": "张小珺Jùn｜商业访谈录",
+    "url": "https://feed.xyzfm.space/dk4yh3pkpjp3",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56584656988676096",
+    "title": "迷因电波",
+    "url": "rsshub://xiaoyuzhou/podcast/61d52b3bee197a3aac3dac44",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "76051724651752448",
+    "title": "极致音乐汇 的 bilibili 空间",
+    "url": "rsshub://bilibili/user/video/1691501735",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "56141546151433216",
+    "title": "胡子观币 - YouTube",
+    "url": "rsshub://youtube/user/%40huziguanbi",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "66701376672681984",
+    "title": "AP Top News - AP News",
+    "url": "rsshub://apnews/api/apf-topnews",
+    "language": "English"
+  },
+  {
+    "feedId": "44366244616936448",
+    "title": "金十数据",
+    "url": "rsshub://jin10",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "52325519371718656",
+    "title": "Hacker News",
+    "url": "rsshub://hackernews",
+    "language": "English"
+  },
+  {
+    "feedId": "41359648684677132",
+    "title": "介绍 on SuperTechFans",
+    "url": "https://www.supertechfans.com/cn/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805276726279",
+    "title": "律动BlockBeats",
+    "url": "https://api.theblockbeats.news/v1/open-api/home-xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54390728350522368",
+    "title": "New Cryptocurrency Listing",
+    "url": "rsshub://binance/announcement/new-cryptocurrency-listing",
+    "language": ""
+  },
+  {
+    "feedId": "41572238278099968",
+    "title": "The world in brief | The Economist",
+    "url": "rsshub://economist/espresso",
+    "language": "English"
+  },
+  {
+    "feedId": "72635895363612672",
+    "title": "Stock Edge",
+    "url": "rsshub://stockedge/daily-updates/news",
+    "language": "English"
+  },
+  {
+    "feedId": "72541421314282496",
+    "title": "Bloomberg - News",
+    "url": "rsshub://bloomberg/%2F",
+    "language": "English"
+  },
+  {
+    "feedId": "74739941830489088",
+    "title": "少数派",
+    "url": "https://sspai.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41489882518602759",
+    "title": "36氪 - 24小时热榜",
+    "url": "rsshub://36kr/hot-list",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41356263889737728",
+    "title": "NASA Astronomy Picture of the Day",
+    "url": "rsshub://nasa/apod",
+    "language": "English",
+    "view": 2
+  },
+  {
+    "feedId": "41719081557593132",
+    "title": "异次元软件世界",
+    "url": "https://feed.iplaysoft.com/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55304291112288259",
+    "title": "每日一图-北京天文馆",
+    "url": "rsshub://bjp/apod",
+    "language": "Chinese",
+    "view": 2
+  },
+  {
+    "feedId": "100011185145959424",
+    "title": "知乎每日精选",
+    "url": "https://www.zhihu.com/rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "60275763819153427",
+    "title": "爱范儿",
+    "url": "https://www.ifanr.com/feed",
+    "language": ""
+  },
+  {
+    "feedId": "41147805276726402",
+    "title": "RSSHub has new routes",
+    "url": "rsshub://rsshub/routes",
+    "language": "English"
+  },
+  {
+    "feedId": "63585517712903168",
+    "title": "AInvest - Latest News",
+    "url": "rsshub://ainvest/news",
+    "language": "English"
+  },
+  {
+    "feedId": "41374973344769024",
+    "title": "阮一峰的网络日志",
+    "url": "https://www.ruanyifeng.com/blog/atom.xml?code=2eb8b88b9919b38e2ce2269980fba393",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100372081228582912",
+    "title": "极客公园",
+    "url": "https://www.geekpark.net/rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41215011978385465",
+    "title": "阮一峰的网络日志",
+    "url": "http://www.ruanyifeng.com/blog/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41443203209057308",
+    "title": "纽约时报中文网",
+    "url": "rsshub://nytimes",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41572238273905680",
+    "title": "IT之家",
+    "url": "https://www.ithome.com/rss/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42520977153904661",
+    "title": "今日热门-什么值得买好文",
+    "url": "rsshub://smzdm/haowen/1",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41486365723425792",
+    "title": "信息差——独立开发者出海周刊",
+    "url": "https://gapis.money/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55653085540614144",
+    "title": "影视飓风 的 bilibili 空间",
+    "url": "rsshub://bilibili/user/video/946974",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "41147805276726276",
+    "title": "美团技术团队",
+    "url": "https://tech.meituan.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818708527117",
+    "title": "宝玉的分享",
+    "url": "https://s.baoyu.io/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41215011978385440",
+    "title": "Pseudoyu",
+    "url": "https://www.pseudoyu.com/zh/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41477724771147777",
+    "title": "老胡的周刊",
+    "url": "https://weekly.howie6879.com/rss/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805268337688",
+    "title": "Owen的博客",
+    "url": "https://www.owenyoung.com/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56535849521479680",
+    "title": "有知有行 - 全部",
+    "url": "rsshub://youzhiyouxing/materials/0",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "58477260865774592",
+    "title": "奇客的资讯，重要的东西",
+    "url": "rsshub://solidot/www",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41503779521380352",
+    "title": "Epic Games Store - Free Games",
+    "url": "rsshub://epicgames/freegames/en-US/US",
+    "language": "English"
+  },
+  {
+    "feedId": "41397727810093057",
+    "title": "奇客Solidot–传递最新科技情报",
+    "url": "https://www.solidot.org/index.rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818712721411",
+    "title": "月光博客",
+    "url": "https://www.williamlong.info/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41461870197170196",
+    "title": "Trending repositories on GitHub today · GitHub",
+    "url": "rsshub://github/trending/daily/any",
+    "language": "English"
+  },
+  {
+    "feedId": "73553160421921792",
+    "title": "少数派 - 派早报",
+    "url": "https://feeds.feedburner.com/sspai/paizaobao",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "72485769266542592",
+    "title": "资讯列表 - 人人影视",
+    "url": "rsshub://yyets/article/all",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41377721131229184",
+    "title": "小Lin说 - YouTube",
+    "url": "rsshub://youtube/user/%40xiao_lin_shuo",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "41572238273905683",
+    "title": "InfoQ 推荐",
+    "url": "rsshub://infoq/recommend",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818708527107",
+    "title": "虹线",
+    "url": "https://1q43.blog/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41492096674907154",
+    "title": "科技圈🎗在花频道📮 - Telegram Channel",
+    "url": "rsshub://telegram/channel/TestFlightCN",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56531023179226112",
+    "title": "HelloGitHub 月刊",
+    "url": "https://hellogithub.com/rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "58463916731079680",
+    "title": "技术爬爬虾 的 bilibili 空间",
+    "url": "rsshub://bilibili/user/video/316183842",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "59403591690626048",
+    "title": "阮一峰的网络日志",
+    "url": "http://feeds.feedburner.com/ruanyifeng",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818704332814",
+    "title": " 太隐 ",
+    "url": "https://wangyurui.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41373653871256591",
+    "title": "竹新社 - Telegram Channel",
+    "url": "rsshub://telegram/channel/tnews365",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "43254215382531115",
+    "title": "Decohack",
+    "url": "https://decohack.com/feed/",
+    "language": "English"
+  },
+  {
+    "feedId": "41147805272531976",
+    "title": "Tw93 Blog",
+    "url": "https://tw93.fun/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805272531968",
+    "title": "Randy's Blog",
+    "url": "https://lutaonan.com/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "59241875117740032",
+    "title": "分享创造日报",
+    "url": "https://v2ex-create.nexmm.com/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41364963690045440",
+    "title": "王志安 - YouTube",
+    "url": "rsshub://youtube/user/%40wangzhian",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "71830193505483776",
+    "title": "McKinsey Greater China - 洞见",
+    "url": "rsshub://mckinsey/cn/25",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56701589104355328",
+    "title": "金色财经 - 全部",
+    "url": "rsshub://jinse/lives/0",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100344100469080064",
+    "title": "机核",
+    "url": "https://www.gcores.com/rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41370691926515712",
+    "title": "小众软件",
+    "url": "https://www.appinn.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "43301307059705856",
+    "title": "站酷总榜设计_创意作品榜_第411期-站酷ZCOOL",
+    "url": "rsshub://zcool/top/design",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058356",
+    "title": "让小产品的独立变现更简单 - ezindie.com",
+    "url": "https://www.ezindie.com/feed/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41707595233790976",
+    "title": "司机社综合周排行榜",
+    "url": "rsshub://xsijishe/rank/weekly",
+    "language": "English"
+  },
+  {
+    "feedId": "57030789598275584",
+    "title": "专题报告 - AI量化知识库 - BigQuant",
+    "url": "rsshub://bigquant/collections",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41795937307751551",
+    "title": "AIGC Weekly",
+    "url": "https://quaily.com/op7418/feed/atom",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818708527124",
+    "title": "槿呈Goidea",
+    "url": "https://justgoidea.com/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41382542902990938",
+    "title": "云风的 BLOG",
+    "url": "https://blog.codingnow.com/atom.xml",
+    "language": ""
+  },
+  {
+    "feedId": "41368476124603392",
+    "title": "Trending repositories on GitHub this week · GitHub",
+    "url": "rsshub://github/trending/weekly/any",
+    "language": "English"
+  },
+  {
+    "feedId": "41427688948323328",
+    "title": "pixiv 日排行",
+    "url": "rsshub://pixiv/ranking/day",
+    "language": "Japanese",
+    "view": 2
+  },
+  {
+    "feedId": "41423034778090522",
+    "title": "周热门-什么值得买好文",
+    "url": "rsshub://smzdm/haowen/7",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "52347176714948614",
+    "title": "Readhub - 每日早报 - Readhub",
+    "url": "rsshub://readhub/daily",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805272531983",
+    "title": "印记",
+    "url": "https://yinji.org/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "57678974871415816",
+    "title": "7x24小时快讯",
+    "url": "rsshub://fx678/kx",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41343619752158231",
+    "title": "酷 壳 – CoolShell",
+    "url": "https://coolshell.cn/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "53014658920611840",
+    "title": "V2EX",
+    "url": "https://www.v2ex.com/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41470051648495616",
+    "title": "ahhhhfs｜A姐分享 - Telegram Channel",
+    "url": "rsshub://telegram/channel/abskoop",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058354",
+    "title": "理想生活实验室",
+    "url": "https://www.toodaylab.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41343619752158230",
+    "title": "BMPI",
+    "url": "https://www.bmpi.dev/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "53352050212694016",
+    "title": "小声逼逼· 软件|资讯|抽奖 - Telegram Channel",
+    "url": "rsshub://telegram/channel/me888888888888",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41470869403557888",
+    "title": "LINUX DO - 最新话题",
+    "url": "https://linux.do/latest.rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55086756782700544",
+    "title": "阿里、夸克、百度等网盘4K影视资源 - Telegram Channel",
+    "url": "rsshub://telegram/channel/Aliyun_4K_Movies",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "61661363869599744",
+    "title": "社群 - 韭研公社-研究共享，茁壮成长（原韭菜公社）",
+    "url": "rsshub://jiuyangongshe/community",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818704332815",
+    "title": "Another Dayu",
+    "url": "https://anotherdayu.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "53033422584152064",
+    "title": "热帖 - 雪球",
+    "url": "rsshub://xueqiu/hots",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805272531984",
+    "title": "张鑫旭-鑫空间-鑫生活",
+    "url": "https://www.zhangxinxu.com/wordpress/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058315",
+    "title": "发现频道 - 小众软件官方论坛",
+    "url": "https://meta.appinn.net/c/faxian/10.rss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42855045334971393",
+    "title": "知乎日报",
+    "url": "https://feedx.net/rss/zhihudaily.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54799935373253632",
+    "title": "阿里云盘吧 - Telegram Channel",
+    "url": "rsshub://telegram/channel/Q66Share",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41381007770949637",
+    "title": "Mac玩儿法",
+    "url": "https://www.waerfa.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54410158488493056",
+    "title": "零度解说 - YouTube",
+    "url": "rsshub://youtube/user/%40%E9%9B%B6%E5%BA%A6%E8%A7%A3%E8%AF%B4",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "52340201851637826",
+    "title": "1Link.Fun 科技周刊 | 每天获取一条高质量的链接",
+    "url": "https://1link.fun/rss/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41358489461613605",
+    "title": "CatCoding",
+    "url": "https://catcoding.me/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "52324311483129856",
+    "title": "阿里云盘发布频道 - Telegram Channel",
+    "url": "rsshub://telegram/channel/shareAliyun",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42176727619514397",
+    "title": "晚点 - 最新报道",
+    "url": "rsshub://latepost",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41501088760162311",
+    "title": "一觉醒来发生了什么 - 即刻圈子",
+    "url": "rsshub://jike/topic/553870e8e4b0cafb0a1bef68",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41511702474276884",
+    "title": "司机社综合月排行榜",
+    "url": "rsshub://xsijishe/rank/monthly",
+    "language": "English"
+  },
+  {
+    "feedId": "42177758872391680",
+    "title": "Mediastorm影视飓风 - YouTube",
+    "url": "rsshub://youtube/user/%40mediastorm6801",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "41359648684677181",
+    "title": "编程随想的博客",
+    "url": "https://feeds2.feedburner.com/programthink",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41215396143077382",
+    "title": "Twitter @Follow",
+    "url": "rsshub://twitter/user/follow_app_",
+    "language": "English",
+    "view": 1
+  },
+  {
+    "feedId": "41492096674907156",
+    "title": "即刻精选 - Telegram Channel",
+    "url": "rsshub://telegram/channel/jike_collection",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "44920595085335552",
+    "title": "虎嗅网",
+    "url": "https://www.huxiu.com/rss/0.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41382542902990947",
+    "title": "土木坛子",
+    "url": "https://tumutanzi.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55765163242101760",
+    "title": "cnBeta.COM - 中文业界资讯站",
+    "url": "rsshub://cnbeta",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41719104290720768",
+    "title": "[今日主题] 技術討論區 | 草榴社區 - t66y.com",
+    "url": "rsshub://t66y/7",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41472267692906513",
+    "title": "二丫讲梵",
+    "url": "https://wiki.eryajf.net/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805272531986",
+    "title": "椒盐豆豉",
+    "url": "https://blog.douchi.space/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "57995444932781056",
+    "title": "GQ",
+    "url": "rsshub://gq/news",
+    "language": "English"
+  },
+  {
+    "feedId": "41383550788723712",
+    "title": " Airing 的博客 ",
+    "url": "https://blog.ursb.me/feed.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41572238273905689",
+    "title": "澎湃新闻 - 首页头条",
+    "url": "rsshub://thepaper/featured",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058329",
+    "title": "卡瓦邦噶！",
+    "url": "https://www.kawabangga.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55216086191994902",
+    "title": "有用经验",
+    "url": "https://yyjingyan.com/index.php/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41343619752158241",
+    "title": " 61’s life ",
+    "url": "https://61.life/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "65017927657675779",
+    "title": "36氪",
+    "url": "https://36kr.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54851744068228138",
+    "title": "极客湾Geekerwan 的 bilibili 空间",
+    "url": "rsshub://bilibili/user/video/25876945",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "67804472989767680",
+    "title": "36氪资讯热榜",
+    "url": "https://feeds.feedburner.com/36kr/hot-list",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359836954400775",
+    "title": "胡涂说",
+    "url": "https://hutusi.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41572238273905693",
+    "title": "纽约时报中文网 - 中英对照版",
+    "url": "rsshub://nytimes/dual",
+    "language": "English"
+  },
+  {
+    "feedId": "57966370728127498",
+    "title": "Breaking News Headlines | Latest Views | Reuters",
+    "url": "rsshub://reuters/breakingviews",
+    "language": "English"
+  },
+  {
+    "feedId": "54737464283059214",
+    "title": "精品MAC应用分享",
+    "url": "https://xclient.info/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41425168656712704",
+    "title": "RSSHub 有新路由啦",
+    "url": "rsshub://rsshub/routes/zh",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41374014364620801",
+    "title": "槽边往事",
+    "url": "https://www.hecaitou.com/feeds/posts/default",
+    "language": "English"
+  },
+  {
+    "feedId": "55160895115655188",
+    "title": "人民日报",
+    "url": "https://plink.anyfeeder.com/people-daily",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "58488203296243712",
+    "title": "人人影视-今日播出",
+    "url": "rsshub://yyets/today",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54772566650461198",
+    "title": "CnGal - 每周速报",
+    "url": "rsshub://cngal/weekly",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "84458689264416768",
+    "title": " 虎嗅 ",
+    "url": "https://rss.huxiu.com/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359690177602678",
+    "title": "MacTalk-池建强的随想录",
+    "url": "https://macshuo.com/?feed=rss2",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "48039983835900989",
+    "title": "電腦玩物",
+    "url": "http://feeds.feedburner.com/playpc",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41397727810093071",
+    "title": "见字如面",
+    "url": "https://hiwannz.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359648680482843",
+    "title": "拾月",
+    "url": "https://www.skyue.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55116179974345728",
+    "title": "彭博社最新报道",
+    "url": "https://bloombergnew.buzzing.cc/feed.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "64999354512147456",
+    "title": "财新周刊 Caixin Weekly",
+    "url": "https://the.bi/s/rawatssj2a2mog",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058314",
+    "title": "#UNTAG",
+    "url": "https://rss.utgd.net/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41374113210459144",
+    "title": "Twitter @宝玉",
+    "url": "rsshub://twitter/user/dotey",
+    "language": "English"
+  },
+  {
+    "feedId": "42331815237783605",
+    "title": "莫比乌斯",
+    "url": "https://onojyun.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41699925856588800",
+    "title": "Nat Geo Photo of the Day",
+    "url": "rsshub://natgeo/dailyphoto",
+    "language": "English"
+  },
+  {
+    "feedId": "42864851888759808",
+    "title": "积薪 - 文章",
+    "url": "https://darmau.co/zh/article/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "52347176714948645",
+    "title": "如有乐享",
+    "url": "https://51.ruyo.net/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805276726317",
+    "title": "pixiv 周排行",
+    "url": "rsshub://pixiv/ranking/week",
+    "language": "Yoruba",
+    "view": 2
+  },
+  {
+    "feedId": "41359836954400804",
+    "title": "王登科-DK博客",
+    "url": "https://greatdk.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058337",
+    "title": "离别歌",
+    "url": "https://www.leavesongs.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "43236301826954240",
+    "title": "不良林 - YouTube",
+    "url": "rsshub://youtube/user/%40bulianglin",
+    "language": "Chinese",
+    "view": 3
+  },
+  {
+    "feedId": "41719081557593137",
+    "title": "我不是咕咕鸽",
+    "url": "https://blog.laoda.de/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42006425715388416",
+    "title": "pinlei榜-11-3小时",
+    "url": "rsshub://smzdm/ranking/pinlei/11/3",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41373653871256582",
+    "title": "风向旗参考快讯 - Telegram Channel",
+    "url": "rsshub://telegram/channel/xhqcankao",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54349807700270080",
+    "title": "知行小酒馆",
+    "url": "rsshub://xiaoyuzhou/podcast/6013f9f58e2f7ee375cf4216",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41343619752158234",
+    "title": "大破进击",
+    "url": "https://jesor.me/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41424303016727552",
+    "title": "老高與小茉 Mr & Mrs Gao - YouTube",
+    "url": "rsshub://youtube/user/%40laogao",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55064361156653076",
+    "title": "子舒的博客",
+    "url": "https://zishu.me/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359690177602681",
+    "title": "奔跑中的奶酪",
+    "url": "https://www.runningcheese.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42579624844251167",
+    "title": "东西智库 – 专注中国制造业高质量发展",
+    "url": "rsshub://dx2025",
+    "language": "English"
+  },
+  {
+    "feedId": "100020530265058338",
+    "title": "Sam Altman",
+    "url": "https://blog.samaltman.com/posts.atom",
+    "language": "English"
+  },
+  {
+    "feedId": "41343619752158254",
+    "title": "OneV's Den",
+    "url": "https://onevcat.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359648684677164",
+    "title": "KAIX.IN",
+    "url": "https://kaix.in/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "60954952175832064",
+    "title": "每日一拍",
+    "url": "rsshub://500px/tribe/set/302261e93f0441c9a5323a565279b0e3",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41461870201364486",
+    "title": "少数派 -- Matrix",
+    "url": "rsshub://sspai/matrix",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818704332817",
+    "title": "Limboy's Essays",
+    "url": "https://limboy.me/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41440449356332064",
+    "title": "Blog | Phodal - A Growth Engineer",
+    "url": "https://www.phodal.com/blog/feeds/rss/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "57164874420868096",
+    "title": "小Lin说 的 bilibili 空间",
+    "url": "rsshub://bilibili/user/video/520819684",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41343619752158232",
+    "title": "罗磊的独立博客",
+    "url": "https://luolei.org/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41423034778090515",
+    "title": "四火的唠叨",
+    "url": "https://www.raychase.net/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41465715829593091",
+    "title": "华尔街日报",
+    "url": "https://feedx.net/rss/wsj.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818716915713",
+    "title": "0x01 byte",
+    "url": "https://1byte.io/articles/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "52508301310328842",
+    "title": "南方周末-新闻",
+    "url": "rsshub://infzm/2",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41358489461613601",
+    "title": "可能吧",
+    "url": "https://feeds.feedburner.com/kenengbarss",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41388765730464778",
+    "title": "GeekPlux",
+    "url": "https://geekplux.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41223694984583197",
+    "title": "静かな森",
+    "url": "https://innei.in/feed",
+    "language": "English"
+  },
+  {
+    "feedId": "41461870201364482",
+    "title": "《联合早报》-中港台-即时",
+    "url": "rsshub://zaobao/realtime/china",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41391604968812544",
+    "title": "纵横四海",
+    "url": "rsshub://xiaoyuzhou/podcast/62694abdb221dd5908417d1e",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55855418052542483",
+    "title": "Elmagnifico's Blog",
+    "url": "https://elmagnifico.tech/feed.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41459996870678548",
+    "title": "掘金本周最热",
+    "url": "https://rsshub.bestblogs.dev/juejin/trending/all/weekly",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805268337670",
+    "title": "小米有品众筹",
+    "url": "rsshub://xiaomiyoupin/crowdfunding",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "48039983835900987",
+    "title": "分享创造",
+    "url": "https://www.v2ex.com/feed/create.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100191225529340928",
+    "title": "游研社",
+    "url": "https://www.yystv.cn/rss/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41380827636851712",
+    "title": "声动早咖啡",
+    "url": "rsshub://xiaoyuzhou/podcast/60de7c003dd577b40d5a40f3",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41667838436032513",
+    "title": "小球飞鱼",
+    "url": "https://mantyke.icu/index.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "61937382761420802",
+    "title": "蓝点网",
+    "url": "https://www.landiannews.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "48039983835900988",
+    "title": "书伴",
+    "url": "https://feeds.feedburner.com/bookfere",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55311155740901376",
+    "title": "有知有行 - 全部",
+    "url": "rsshub://youzhiyouxing/materials",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100157598308965376",
+    "title": "V2EX - 创意",
+    "url": "https://www.v2ex.com/feed/tab/creative.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41798923170845776",
+    "title": "初之音",
+    "url": "https://www.himiku.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "57419814936869901",
+    "title": "不死鸟 - 分享为王官网",
+    "url": "https://iui.su/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "70126938108248064",
+    "title": "财联社快讯",
+    "url": "https://feeds.crabpi.com/cls-telegraph",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41461870197170197",
+    "title": "豌豆花下猫",
+    "url": "https://pythoncat.top/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "54083984224404480",
+    "title": "酷安图文 - 编辑精选",
+    "url": "rsshub://coolapk/tuwen",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359690177602682",
+    "title": "唐巧的博客",
+    "url": "https://blog.devtang.com/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "69670759328198656",
+    "title": "IMDb Top 250 Movies",
+    "url": "rsshub://imdb/chart/top",
+    "language": "English"
+  },
+  {
+    "feedId": "100020530265058320",
+    "title": "卢昌海个人主页",
+    "url": "https://www.changhai.org/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100080366298125312",
+    "title": "The Verge",
+    "url": "https://www.theverge.com/rss/index.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41527687227405342",
+    "title": "吾爱破解论坛",
+    "url": "https://wechat2rss.xlab.app/feed/90c827b8290310a96ef80a13df9dbcc06ab69892.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "54945423970185247",
+    "title": "晚晴幽草轩",
+    "url": "https://www.jeffjade.com/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "67048226833723428",
+    "title": "ahhhhfs",
+    "url": "https://www.ahhhhfs.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "42331815237783583",
+    "title": "木木木木木",
+    "url": "https://immmmm.com/atom.xml",
+    "language": "English"
+  },
+  {
+    "feedId": "41768239731545103",
+    "title": "laike9m's blog",
+    "url": "https://laike9m.com/blog/rss/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55576111518416909",
+    "title": "豆瓣电影本周口碑榜",
+    "url": "https://feedx.net/rss/doubanmvweek.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41147805272531974",
+    "title": "t9t.io",
+    "url": "https://blog.t9t.io/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359836954400809",
+    "title": "月球背面",
+    "url": "https://moonvy.com/blog/rss.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41459996870678529",
+    "title": "量子位",
+    "url": "https://www.qbitai.com/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41376358301079552",
+    "title": "三联生活周刊",
+    "url": "https://plink.anyfeeder.com/weixin/lifeweek",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41768239731545124",
+    "title": "依云's Blog",
+    "url": "https://blog.lilydjwg.me/feed?code=c6f56c4214621ab98b86acbcae6b4405",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359648684677153",
+    "title": "海德沙龙（HeadSalon）",
+    "url": "https://headsalon.org/feed",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41667283719128072",
+    "title": "技术小黑屋",
+    "url": "https://droidyue.com/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41342818704332811",
+    "title": "陈仓颉",
+    "url": "https://imzm.im/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55130722692595719",
+    "title": "笨方法学写作",
+    "url": "https://www.cnfeat.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55877082660306949",
+    "title": "数据发布 - 国家统计局",
+    "url": "rsshub://gov/stats/sj/zxfb",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "43789642870889493",
+    "title": "Tony Bai",
+    "url": "https://tonybai.com/feed/",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "55157116408461312",
+    "title": "Macin",
+    "url": "https://macin.org/atom.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100020530265058312",
+    "title": "歸藏的AI工具箱",
+    "url": "https://werss.bestblogs.dev/feeds/MP_WXS_3540975510.atom",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41324816676184075",
+    "title": "Yu’s Life - Telegram Channel",
+    "url": "rsshub://telegram/channel/pseudoyulife",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "43374760408291328",
+    "title": "Epic Games Store - Free Games",
+    "url": "rsshub://epicgames/freegames/zh-CN/CN",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "100127086160845862",
+    "title": "一天一篇经济学人(双语)",
+    "url": "https://plink.anyfeeder.com/weixin/Economist_fans",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "56587971459683328",
+    "title": "技术爬爬虾 TechShrimp - YouTube",
+    "url": "rsshub://youtube/user/%40Tech_Shrimp",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41359648684677157",
+    "title": "阳志平的网志",
+    "url": "https://www.yangzhiping.com/feed.xml",
+    "language": "Chinese"
+  },
+  {
+    "feedId": "41459996870678583",
+    "title": "机器之心",
+    "url": "https://www.jiqizhixin.com/rss",
+    "language": "Chinese"
+  }
+]

--- a/apps/mobile/src/modules/onboarding/preset.ts
+++ b/apps/mobile/src/modules/onboarding/preset.ts
@@ -1,4 +1,8 @@
 import { FeedViewType } from "@follow/constants"
+import { getLocales } from "expo-localization"
+
+import feeds from "./feeds.json"
+import englishFeeds from "./feeds-english.json"
 
 export type PresetFeedConfig = {
   title: string
@@ -7,116 +11,21 @@ export type PresetFeedConfig = {
   view: FeedViewType
 }
 
-export const presetFeeds: PresetFeedConfig[] = [
-  {
-    feedId: "41358761177015296",
-    title: "知乎热榜 - 全站",
-    url: "rsshub://zhihu/hot/total",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "100020530265058357",
-    title: "阮一峰的网络日志",
-    url: "https://feeds.feedburner.com/ruanyifeng",
-    view: FeedViewType.Articles,
-  },
+export const englishPresetFeeds: PresetFeedConfig[] = englishFeeds.map((feed) => ({
+  view: FeedViewType.Articles,
+  ...feed,
+}))
 
-  {
-    feedId: "41358830592746496",
-    title: "微博热搜榜",
-    url: "rsshub://weibo/search/hot",
-    view: FeedViewType.SocialMedia,
-  },
-  {
-    feedId: "100411504863520768",
-    title: "Twitter @Elon Musk",
-    url: "rsshub://twitter/user/elonmusk",
-    view: FeedViewType.SocialMedia,
-  },
-  {
-    feedId: "41324816676184077",
-    title: "Twitter @DIŸgöd ☀️",
-    url: "rsshub://twitter/user/DIYgod",
-    view: FeedViewType.SocialMedia,
-  },
+export const otherPresetFeeds: PresetFeedConfig[] = feeds
+  // .filter((feed) => feed.language === "Chinese")
+  .map((feed) => ({
+    view: FeedViewType.Articles,
+    ...feed,
+  }))
 
-  {
-    feedId: "78806242632741888",
-    title: "bilibili 排行榜-全站",
-    url: "rsshub://bilibili/ranking/0",
-    view: FeedViewType.Videos,
-  },
+const locales = getLocales()
+// `getLocales` guaranteed to contain at least 1 element.
+const languageTag = locales[0]?.languageTag || "en-US"
+const isEnglishUser = languageTag.startsWith("en")
 
-  {
-    feedId: "60338304723722240",
-    title: "实时财经快讯 - FastBull",
-    url: "rsshub://fastbull/express-news",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "55611390687386624",
-    title: "格隆汇快讯-7x24小时市场快讯-财经市场热点",
-    url: "rsshub://gelonghui/live",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "49375919416104960",
-    title: "深潮TechFlow - 快讯",
-    url: "rsshub://techflowpost/express",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "55982073122828305",
-    title: "TED Talks Daily",
-    url: "https://feeds.acast.com/public/shows/67587e77c705e441797aff96",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "72541715399995392",
-    title: "TheBlockBeats - 快讯",
-    url: "rsshub://theblockbeats/newsflash/0",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "100184911354754055",
-    title: "小Lin说",
-    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCilwQlk62k1z7aUEZPOB6yw",
-    view: FeedViewType.Videos,
-  },
-  {
-    feedId: "100185810923910148",
-    title: "张小珺Jùn｜商业访谈录",
-    url: "https://feed.xyzfm.space/dk4yh3pkpjp3",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "56584656988676096",
-    title: "迷因电波",
-    url: "rsshub://xiaoyuzhou/podcast/61d52b3bee197a3aac3dac44",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "76051724651752448",
-    title: "极致音乐汇 的 bilibili 空间",
-    url: "rsshub://bilibili/user/video/1691501735",
-    view: FeedViewType.Videos,
-  },
-  {
-    feedId: "66701376672681984",
-    title: "AP Top News - AP News",
-    url: "rsshub://apnews/api/apf-topnews",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "44366244616936448",
-    title: "金十数据",
-    url: "rsshub://jin10",
-    view: FeedViewType.Articles,
-  },
-  {
-    feedId: "52325519371718656",
-    title: "Hacker News",
-    url: "rsshub://hackernews",
-    view: FeedViewType.Articles,
-  },
-]
+export const presetFeeds = isEnglishUser ? englishPresetFeeds : otherPresetFeeds

--- a/apps/mobile/src/store/user/hooks.ts
+++ b/apps/mobile/src/store/user/hooks.ts
@@ -25,8 +25,9 @@ export const useUser = (userId?: string) => {
   return useUserStore((state) => (userId ? state.users[userId] : undefined))
 }
 
-export function useIsNewUser() {
+export function useIsNewUser(enabled = true) {
   const { data } = useQuery({
+    enabled,
     queryKey: isNewUserQueryKey,
     queryFn: async () => {
       const isOnboardingFinished = await kv.get(isOnboardingFinishedStorageKey)
@@ -42,7 +43,8 @@ export function useIsNewUser() {
 }
 
 export function useOnboarding() {
-  const isNewUser = useIsNewUser()
+  const whoami = useWhoami()
+  const isNewUser = useIsNewUser(!!whoami)
   useEffect(() => {
     if (isNewUser) {
       router.push("/onboarding")


### PR DESCRIPTION
Introduce language detection to provide users with preset feeds tailored to their language preferences during onboarding. English users receive a specific set of feeds, while others access a different collection.