### PR TITLE
fix(desktop): incorrect svg favicon name

### DIFF
--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121212" />
     <!-- favicon -->
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
-    <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />
+    <link rel="icon" href="/icon.svg" sizes="any" type="image/svg+xml" />
     <!-- FireFox -->
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -11,7 +11,7 @@
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#121212" />
     <!-- favicon -->
-    <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="icon" href="/favicon.ico" sizes="48x48" type="image/x-icon" />
     <link rel="icon" href="/icon.svg" sizes="any" type="image/svg+xml" />
     <!-- FireFox -->
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />

--- a/apps/ssr/index.html
+++ b/apps/ssr/index.html
@@ -11,7 +11,8 @@
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#000000" />
 
-    <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="icon" href="/favicon.ico" sizes="48x48" type="image/x-icon" />
+    <link rel="icon" href="/icon.svg" sizes="any" type="image/svg+xml" />
     <!-- FireFox -->
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <title>Follow</title>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
For some reason, the name of the `favicon.svg`, which was supposed to be the main favicon resource for this project, was changed. For a long time, the project had been using a fallback `.ico` icon.

However, it seems that Firefox did not handle compatibility well, even when the fetched SVG was missing or incorrect, it did not fallback to the `.ico` icon.

![image](https://github.com/user-attachments/assets/d75de8ae-b33e-42db-a455-16df3b1367e4)
![image](https://github.com/user-attachments/assets/487f1c62-5d32-4af5-a130-6e319d919fc4)

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)
![image](https://github.com/user-attachments/assets/4ddc5714-20ac-4f70-8c1b-9b35b462be4d)


### Demo Video (if new feature)

### Linked Issues

close #3139 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
