### PR TITLE
fix(desktop): handle audio metadata loading and reset current time

### DIFF
--- a/apps/desktop/src/renderer/src/atoms/player.ts
+++ b/apps/desktop/src/renderer/src/atoms/player.ts
@@ -99,8 +99,11 @@ export const AudioPlayer = {
         currentTime: this.audio.currentTime,
       })
     }, 1000)
-    if (Number.isNaN(this.audio.duration) || this.audio.duration === Infinity) {
-      this.audio.currentTime = 0
+
+    this.audio.onloadedmetadata = () => {
+      if (Number.isNaN(this.audio.duration) || this.audio.duration === Infinity) {
+        this.audio.currentTime = 0
+      }
     }
 
     const currentActionId = this.__currentActionId


### PR DESCRIPTION
When you quit the app, though it has stored `currentTime` value. `currentTime` will be 0 after you click the play button.


Before:

https://github.com/user-attachments/assets/153ec89e-becb-48bc-a447-36fdae166d4c


After:

https://github.com/user-attachments/assets/5736fb7e-f99d-4bac-9631-fd97105383a3

