### PR TITLE
fix: update tailwind varint

### DIFF
--- a/packages/configs/tailwindcss/tailwind-extend.css
+++ b/packages/configs/tailwindcss/tailwind-extend.css
@@ -99,7 +99,7 @@
 /* Checkbox */
 @layer components {
   .checkbox {
-    --chkbg: theme(colors.theme.accent.DEFAULT);
+    --chkbg: theme(colors.accent);
     --chkfg: theme(colors.zinc.100);
 
     flex-shrink: 0;
@@ -121,8 +121,8 @@
     outline-style: solid;
     outline-width: 2px;
     outline-offset: 2px;
-    outline-color: theme(colors.theme.accent.DEFAULT);
-    border-color: theme(colors.theme.accent.DEFAULT);
+    outline-color: theme(colors.accent);
+    border-color: theme(colors.accent);
   }
 
   .checkbox:disabled {
@@ -138,7 +138,7 @@
   .checkbox[aria-checked="true"] {
     background-repeat: no-repeat;
     animation: checkmark var(--animation-input, 0.2s) ease-out;
-    border-color: theme(colors.theme.accent.DEFAULT);
+    border-color: theme(colors.accent);
     background-color: var(--chkbg);
     background-image:
       linear-gradient(-45deg, transparent 65%, var(--chkbg) 65.99%),
@@ -183,10 +183,7 @@
 @layer components {
   .follow-link--underline {
     color: currentColor;
-    background-image: linear-gradient(
-      theme(colors.theme.accent.DEFAULT),
-      theme(colors.theme.accent.DEFAULT)
-    );
+    background-image: linear-gradient(theme(colors.accent), theme(colors.accent));
     background-size: 0% 1.5px;
     background-repeat: no-repeat;
     /* NOTE: this won't work with background images   */


### PR DESCRIPTION
The config doesn't have `colors.theme.accent.DEFAULT` anymore. Need to update this to `colors.accent`

<img width="991" alt="image" src="https://github.com/user-attachments/assets/2a95c76a-0dc6-4337-9b54-bf43bb90865e" />
