### PR TITLE
fix(desktop): improve preview player style

### DIFF
--- a/apps/desktop/layer/renderer/src/components/ui/media/Media.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/Media.tsx
@@ -520,7 +520,7 @@ const VideoPreview: FC<{
           poster={previewImageUrl}
           ref={setVideoRef}
           muted
-          className="relative size-full object-cover"
+          className="not-prose relative size-full object-cover"
         />
       )}
 

--- a/apps/desktop/layer/renderer/src/components/ui/media/VideoPlayer.tsx
+++ b/apps/desktop/layer/renderer/src/components/ui/media/VideoPlayer.tsx
@@ -145,7 +145,7 @@ export const VideoPlayer = ({
       scope={HotkeyScope.VideoPlayer}
     >
       {element}
-      <div className="center pointer-events-none absolute">
+      <div className="center pointer-events-none absolute inset-0">
         <m.div
           className="center flex size-20 rounded-full bg-black p-3"
           style={{ scale: scaleValue, opacity: opacityValue }}
@@ -195,7 +195,7 @@ const FloatMutedButton = () => {
   const isMuted = ctx.state.muted
   return (
     <MotionButtonBase
-      className="center absolute right-2 top-10 z-10 size-7 rounded-full bg-black/50 opacity-0 duration-200 group-hover:opacity-100"
+      className="center absolute right-4 top-4 z-10 size-7 rounded-full bg-black/50 opacity-0 duration-200 group-hover:opacity-100"
       onClick={(e) => {
         e.stopPropagation()
         if (isMuted) {


### PR DESCRIPTION
1.  Like a white dot but it caused by the background.

<img width="400" alt="CleanShot 2025-07-24 at 17 53 44" src="https://github.com/user-attachments/assets/8285ca9b-398e-4956-9ff9-16d8a7ec237c" />

2. `FloatMutedButton`'s wrong position.

<table>
<tr>

<td>
<img width="1196" height="1182" alt="CleanShot 2025-07-24 at 18 07 36" src="https://github.com/user-attachments/assets/97817212-b140-4a17-a563-fd600c886287" />

<td>
<img width="1210" height="1192" alt="CleanShot 2025-07-24 at 18 07 16" src="https://github.com/user-attachments/assets/7c1158f8-8c57-40fc-940f-7d58631b5eac" />
</table


