### PR TITLE
feat: add relative time display for message timestamps

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/AIChatMessage.tsx
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/AIChatMessage.tsx
@@ -5,6 +5,7 @@ import { m } from "motion/react"
 import * as React from "react"
 import { toast } from "sonner"
 
+import { RelativeTime } from "~/components/ui/datetime"
 import { copyToClipboard } from "~/lib/clipboard"
 import type { BizUIMessage } from "~/modules/ai-chat/store/types"
 
@@ -114,7 +115,10 @@ export const AIChatMessage: React.FC<AIChatMessageProps> = React.memo(
 
           {/* Action buttons */}
           {!!originalMessage.metadata?.finishTime && (
-            <div className="absolute -left-2 bottom-1 right-0 flex gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+            <div className="absolute -left-2 bottom-1 right-0 flex items-center gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+              <span className="text-text-tertiary whitespace-nowrap px-2 py-1 text-[11px] leading-none">
+                <RelativeTime date={originalMessage.createdAt} />
+              </span>
               <button
                 type="button"
                 onClick={handleCopy}

--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/UserChatMessage.tsx
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/message/UserChatMessage.tsx
@@ -4,6 +4,7 @@ import type { LexicalEditor, SerializedEditorState } from "lexical"
 import { AnimatePresence, m } from "motion/react"
 import * as React from "react"
 
+import { RelativeTime } from "~/components/ui/datetime"
 import { useEditingMessageId, useSetEditingMessageId } from "~/modules/ai-chat/atoms/session"
 import { useChatActions, useChatStatus } from "~/modules/ai-chat/store/hooks"
 import type { AIChatContextBlock, BizUIMessage } from "~/modules/ai-chat/store/types"
@@ -147,13 +148,16 @@ export const UserChatMessage: React.FC<UserChatMessageProps> = React.memo(({ mes
             {/* Action buttons - only show when not editing */}
             {!isEditing && (
               <m.div
-                className="absolute bottom-1 right-0 flex gap-1"
+                className="absolute bottom-1 right-0 flex items-center gap-1"
                 initial={{ opacity: 0 }}
                 animate={{
                   opacity: isHovered ? 1 : 0,
                 }}
                 transition={{ duration: 0.2, ease: "easeOut" }}
               >
+                <span className="text-text-tertiary whitespace-nowrap px-2 py-1 text-[11px] leading-none">
+                  <RelativeTime date={message.createdAt} />
+                </span>
                 <button
                   type="button"
                   onClick={handleEdit}


### PR DESCRIPTION
Introduce a feature that displays message timestamps in a relative format, enhancing the user experience by providing clearer context for message timing.

<img width="330" height="184" alt="image" src="https://github.com/user-attachments/assets/403e59ab-a37a-4fee-b324-75031119639a" />


<img width="549" height="312" alt="image" src="https://github.com/user-attachments/assets/39085e54-160f-4ede-8cb3-69ed34183274" />
