### PR TITLE
fix: toast close button was clipped and its focus style

### DIFF
--- a/packages/internal/components/src/ui/toast/styles.ts
+++ b/packages/internal/components/src/ui/toast/styles.ts
@@ -68,7 +68,7 @@ export const toastStyles = {
     transition-all duration-200
     opacity-0 group-hover:opacity-100
     focus:outline-none focus:ring-2
-     group-data-[type=default]:focus:ring-[rgba(255,92,0,0.5)]
+    group-data-[type=default]:focus:ring-[rgba(255,92,0,0.5)]
     group-data-[type=success]:focus:ring-[rgba(40,205,65,0.5)]
     group-data-[type=error]:focus:ring-[rgba(255,69,58,0.5)]
     group-data-[type=warning]:focus:ring-[rgba(255,149,0,0.5)]


### PR DESCRIPTION
1. the close button is clipped

2. the style of close button when its clicked, its ring style was always accent color. we can make it adjust the event status.

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>

<img width="836" height="262" alt="CleanShot 2025-10-26 at 01 48 20@2x" src="https://github.com/user-attachments/assets/4bd26229-a80c-43b3-9d80-5243eaafdb8a" />

 <td>

https://github.com/user-attachments/assets/f95eee3c-acf6-46f9-a031-6917c29ef579


</table>