### PR TITLE
fix(EntryContent): updated button styles for entry navigation

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-content/EntryContent.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-content/EntryContent.tsx
@@ -157,11 +157,8 @@ const EntryContentImpl: Component<EntryContentProps> = ({
             <>
               <div className="absolute inset-y-0 left-0 z-[9] flex w-12 items-center justify-center opacity-0 duration-200 hover:opacity-100 group-hover:opacity-40">
                 <GlassButton
-                  aria-label="Previous entry"
-                  description="Previous entry"
                   size="sm"
-                  variant="flat"
-                  className="!-translate-y-12"
+                  className="!-translate-y-12 !bg-material-opaque !opacity-100 hover:!bg-material-opaque"
                   onClick={() => {
                     EventBus.dispatch(COMMAND_ID.timeline.switchToPrevious)
                   }}
@@ -172,11 +169,8 @@ const EntryContentImpl: Component<EntryContentProps> = ({
 
               <div className="absolute inset-y-0 right-0 z-[9] flex w-12 items-center justify-center opacity-0 duration-200 hover:opacity-100 group-hover:opacity-40">
                 <GlassButton
-                  aria-label="Next entry"
-                  description="Next entry"
                   size="sm"
-                  variant="flat"
-                  className="!-translate-y-12"
+                  className="!-translate-y-12 !bg-material-opaque !opacity-100 hover:!bg-material-opaque"
                   onClick={() => {
                     EventBus.dispatch(COMMAND_ID.timeline.switchToNext)
                   }}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When at critical width, the entry navigation button will invade content area, which lacking a clear background, shadow, or blur overlay, making it difficult for users to distinguish them as overlay elements rather than part of the main content.

<img width="728" height="243" alt="image" src="https://github.com/user-attachments/assets/c71cf851-194c-4dbd-b5eb-b578f767d986" />

Therefore, this PR updated the style of entry navigation button with border and background color to indicate its overlay state.

<img width="299" height="125" alt="image" src="https://github.com/user-attachments/assets/b546884e-67ab-4f3c-bf01-9a383110c085" />

The style mimics the AIShortcutButton in the sidebar to maintain overall stylistic consistency.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

<img width="1462" height="856" alt="image" src="https://github.com/user-attachments/assets/3ee17ab9-0d9e-4a56-8f5a-d83cc017c1a5" />

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
