### PR TITLE
fix(desktop): first item's action bar was obscured by header

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/item.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/item.tsx
@@ -14,11 +14,13 @@ interface EntryItemProps {
   entryId: string
   view: FeedViewType
   currentFeedTitle?: string
+  isFirstItem?: boolean
 }
 const EntryItemImpl = memo(function EntryItemImpl({
   entryId,
   view,
   currentFeedTitle,
+  isFirstItem,
 }: EntryItemProps) {
   const enableTranslation = useGeneralSettingKey("translation")
   const actionLanguage = useActionLanguage()
@@ -37,7 +39,12 @@ const EntryItemImpl = memo(function EntryItemImpl({
   const Item: EntryListItemFC = getItemComponentByView(view)
 
   return (
-    <EntryItemWrapper itemClassName={Item.wrapperClassName} entryId={entryId} view={view}>
+    <EntryItemWrapper
+      itemClassName={Item.wrapperClassName}
+      entryId={entryId}
+      view={view}
+      isFirstItem={isFirstItem}
+    >
       <Item entryId={entryId} translation={translation} currentFeedTitle={currentFeedTitle} />
     </EntryItemWrapper>
   )
@@ -65,9 +72,16 @@ export const EntryVirtualListItem = ({
 
   if (!hasEntry) return <div ref={ref} {...props} style={undefined} />
 
+  const isFirstItem = props["data-index"] === 0
+
   return (
     <div className="absolute left-0 top-0 w-full will-change-transform" ref={ref} {...props}>
-      <EntryItemImpl entryId={entryId} view={view} currentFeedTitle={currentFeedTitle} />
+      <EntryItemImpl
+        entryId={entryId}
+        view={view}
+        currentFeedTitle={currentFeedTitle}
+        isFirstItem={isFirstItem}
+      />
     </div>
   )
 }

--- a/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryItemWrapper.tsx
@@ -32,10 +32,11 @@ export const EntryItemWrapper: FC<
   {
     entryId: string
     view: FeedViewType
+    isFirstItem?: boolean
     itemClassName?: string
     style?: React.CSSProperties
   } & PropsWithChildren
-> = ({ entryId, view, children, itemClassName, style }) => {
+> = ({ entryId, view, children, itemClassName, style, isFirstItem }) => {
   const entry = useEntry(entryId, (state) => {
     const { feedId, inboxHandle } = state
     const { id, url } = state
@@ -173,6 +174,7 @@ export const EntryItemWrapper: FC<
                 void openContextMenuAt(x, y)
               }}
               entryId={entryId}
+              isFirstItem={!!isFirstItem}
             />
           )}
         </AnimatePresence>
@@ -184,9 +186,11 @@ export const EntryItemWrapper: FC<
 const ActionBar = ({
   entryId,
   openContextMenu,
+  isFirstItem,
 }: {
   entryId: string
   openContextMenu: () => void
+  isFirstItem: boolean
 }) => {
   const { view } = useRouteParams()
 
@@ -196,6 +200,7 @@ const ActionBar = ({
     <div
       className={cn(
         "absolute -right-2 top-0 -translate-y-1/2 rounded-lg border border-gray-200 bg-white/90 p-1 shadow-sm backdrop-blur-sm dark:border-neutral-900 dark:bg-neutral-900",
+        isFirstItem && "-right-2 top-4",
         view === FeedViewType.All && "right-1 top-1/2",
       )}
       onClick={(e) => {


### PR DESCRIPTION
I don't know whether if it is the solution.

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="2500" height="218" alt="CleanShot 2025-10-28 at 11 07 07@2x" src="https://github.com/user-attachments/assets/ef9d211a-c570-4c66-b9d3-bf3da4e2b6ad" />

 <td>
<img width="2214" height="334" alt="CleanShot 2025-10-28 at 11 06 52@2x" src="https://github.com/user-attachments/assets/dccaeb39-7a5b-4955-ab06-bfb3a6d9f73c" />

</table>