### PR TITLE
fix(desktop): increase height for preview header style

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -92,7 +92,7 @@ export const EntryListHeader: FC<{
         "flex h-top-header-with-border-b w-full flex-col pr-2.5 pt-2 @[700px]:pr-3 @[1024px]:pr-4",
         !feedColumnShow && "macos:mt-4 macos:pt-margin-macos-traffic-light-y",
         titleStyleBasedView[view],
-        isPreview && "px-2.5 @[700px]:px-3 @[1024px]:px-4",
+        isPreview && "h-top-header-in-preview-with-border-b px-2.5 @[700px]:px-3 @[1024px]:px-4",
         view === FeedViewType.All &&
           "border-b border-transparent data-[scrolled-beyond-threshold=true]:border-b-border",
       )}

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -50,6 +50,7 @@ export default extendConfig({
         // 2 + 0.625 * 2 = 3.25
         "top-header": "3.25rem",
         "top-header-with-border-b": "calc(3.25rem + 1px)",
+        "top-header-in-preview-with-border-b": "calc(3.25rem + 41px)",
       },
       colors: {
         sidebar: "hsl(var(--fo-sidebar) / <alpha-value>)",


### PR DESCRIPTION
<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="2662" height="282" alt="CleanShot 2025-10-29 at 11 51 07@2x" src="https://github.com/user-attachments/assets/48c90542-c39f-44da-8c4b-ffc84dd65a83" />

 <td>
<img width="2590" height="306" alt="CleanShot 2025-10-29 at 14 02 22@2x" src="https://github.com/user-attachments/assets/44dd79db-291d-4238-9f86-5515f039e8f8" />

<tr>
 <td>

<img width="794" height="368" alt="CleanShot 2025-10-29 at 11 51 01@2x" src="https://github.com/user-attachments/assets/28f6c273-e72e-439a-9b6d-1363b306018f" />

 <td>
<img width="874" height="470" alt="CleanShot 2025-10-29 at 14 02 16@2x" src="https://github.com/user-attachments/assets/81c6a31f-954c-4ce5-a580-18b8dc494c81" />

</table>