### PR TITLE
fix: enable manual timeline summary override when switching chats

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/layouts/ChatHistoryDropdown.tsx
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/layouts/ChatHistoryDropdown.tsx
@@ -107,7 +107,12 @@ export const ChatHistoryDropdown = ({
             {sessions.map((session) => (
               <DropdownMenuItem
                 key={session.chatId}
-                onClick={() => startTransition(() => chatActions.switchToChat(session.chatId))}
+                onClick={() =>
+                  startTransition(() => {
+                    chatActions.setTimelineSummaryManualOverride(true)
+                    chatActions.switchToChat(session.chatId)
+                  })
+                }
                 className="group flex h-8 cursor-pointer items-center justify-between rounded-md px-2 py-3"
               >
                 <div className="min-w-0 flex-1">


### PR DESCRIPTION
Implement a manual override for the timeline summary when switching between chats, enhancing user control over chat history display.