### PR TITLE
fix: correct header height class assignment

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -89,10 +89,12 @@ export const EntryListHeader: FC<{
   return (
     <div
       className={cn(
-        "flex h-top-header-with-border-b w-full flex-col pr-2.5 pt-2 @[700px]:pr-3 @[1024px]:pr-4",
+        "flex w-full flex-col pr-2.5 pt-2 @[700px]:pr-3 @[1024px]:pr-4",
         !feedColumnShow && "macos:mt-4 macos:pt-margin-macos-traffic-light-y",
         titleStyleBasedView[view],
-        isPreview && "h-top-header-in-preview-with-border-b px-2.5 @[700px]:px-3 @[1024px]:px-4",
+        isPreview
+          ? "h-top-header-in-preview-with-border-b px-2.5 @[700px]:px-3 @[1024px]:px-4"
+          : "h-top-header-with-border-b",
         view === FeedViewType.All &&
           "border-b border-transparent data-[scrolled-beyond-threshold=true]:border-b-border",
       )}


### PR DESCRIPTION
I’m not sure why the screenshots in #4628 looked correct, but after testing with the latest code, the issue reappeared.

After checking the code, I noticed that the last class `h-top-header-in-preview-with-border-b` was overridden by the previous class `h-top-header-with-border-b`.

<img width="2416" height="342" alt="CleanShot 2025-11-02 at 23 51 42@2x" src="https://github.com/user-attachments/assets/e9db15b7-d2f4-421c-8c36-51767290ebb5" />

The issue occurs because in the generated css, the declaration for `h-top-header-with-border-b` appears after `h-top-header-in-preview-with-border-b`, causing its styles to override the preview one.

<img width="400" alt="CleanShot 2025-11-03 at 00 09 17@2x" src="https://github.com/user-attachments/assets/fd77d61f-132e-4c7b-9c29-803c2665dff4" />

So this solution is the right way to handle it. 

/cc @Innei 