### PR TITLE
fix: scope pictureViewImageOnly to picture feeds

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
@@ -115,7 +115,8 @@ const VirtualGridImpl: FC<
     return Array.from({ length: columnCount }).fill(width / columnCount) as number[]
   }, [containerWidth])
 
-  const isImageOnly = useUISettingKey("pictureViewImageOnly")
+  const pictureViewImageOnly = useUISettingKey("pictureViewImageOnly")
+  const isImageOnly = view === FeedViewType.Pictures && pictureViewImageOnly
 
   // Calculate rows based on entries
   const rows = useMemo(() => {

--- a/apps/desktop/layer/renderer/src/modules/entry-column/templates/grid-item-template.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/templates/grid-item-template.tsx
@@ -1,4 +1,5 @@
 import { TitleMarquee } from "@follow/components/ui/marquee/index.jsx"
+import { FeedViewType } from "@follow/constants"
 import { useIsEntryStarred } from "@follow/store/collection/hooks"
 import { useEntry, useHasEntry } from "@follow/store/entry/hooks"
 import { useFeedById } from "@follow/store/feed/hooks"
@@ -9,6 +10,7 @@ import { useTranslation } from "react-i18next"
 
 import { useUISettingKey } from "~/atoms/settings/ui"
 import { useEntryIsRead } from "~/hooks/biz/useAsRead"
+import { useRouteParamsSelector } from "~/hooks/biz/useRouteParams"
 import { EntryTranslation } from "~/modules/entry-column/translation"
 import type { FeedIconEntry } from "~/modules/feed/feed-icon"
 import { FeedIcon } from "~/modules/feed/feed-icon"
@@ -80,7 +82,9 @@ export const GridItemFooter = ({
   const { t } = useTranslation("common")
 
   const isImageOnly = useUISettingKey("pictureViewImageOnly")
-  if (isImageOnly) return null
+  const view = useRouteParamsSelector(({ view }) => view)
+  const shouldHideFooter = view === FeedViewType.Pictures && isImageOnly
+  if (shouldHideFooter) return null
 
   if (!entry) return null
   return (


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The image-only setting for picture view will also affect video view, which should be unexpected since there is no toggler.  

This PR limits the picture-only setting to the Pictures timeline so other views (like Videos) keep their metadata visible.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

- before

https://github.com/user-attachments/assets/433aef0f-ba4d-4759-ba3c-964ab7ea8bbf

- after

https://github.com/user-attachments/assets/c4a6d9d2-e7be-4237-ae2a-cb8a583d39a4


### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
