### PR TITLE
fix(desktop): Discover page shakes when switching tabs

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/app-layout/subview/SubviewLayout.tsx
+++ b/apps/desktop/layer/renderer/src/modules/app-layout/subview/SubviewLayout.tsx
@@ -111,6 +111,7 @@ function SubviewLayoutInner() {
       location.pathname === Routes.Discover &&
       scrollRef
     ) {
+      if (scrollRef.scrollTop === 0) return
       springScrollTo(0, scrollRef)
     }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

On the Discover page, when switching between tabs, the page shakes. Notice the "Discover" text at the top.

The reason is that the code performs a check, which causes the page to scroll to the top.
My solution is to avoid scrolling to the top when the page is already at the top.

**before**

https://github.com/user-attachments/assets/cc81f2b2-d2d5-4193-bde0-6088d4c0177e

**after**

https://github.com/user-attachments/assets/fc495e73-298e-4d03-993c-bec80958721e




### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
