### PR TITLE
fix: correct jsonEscape logic and trim headers in fetch template processing

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/integration/custom-integration-manager.ts
+++ b/apps/desktop/layer/renderer/src/modules/integration/custom-integration-manager.ts
@@ -182,7 +182,7 @@ export class CustomIntegrationManager {
       const processedKey = this.replacePlaceholders(key, context)
       const processedValue = this.replacePlaceholders(value, context)
       // Field names are case-insensitive.
-      processedHeaders[processedKey.toLowerCase()] = processedValue
+      processedHeaders[processedKey.toLowerCase().trim()] = processedValue.trim()
     })
 
     // Process body without URL encoding


### PR DESCRIPTION
Fix https://github.com/RSSNext/Folo/issues/1096

Improve the handling of JSON escape logic and ensure that processed header keys and values are trimmed for consistency in fetch template processing.