### PR TITLE
fix(workflow): clean disk space

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -32,6 +32,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 🧹 Claim disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/julia*
+          df -h /
+
       - name: 📦 Checkout code
         uses: actions/checkout@v6
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Hopefully address the issue of https://github.com/RSSNext/Folo/actions/runs/20552478820 `System.IO.IOException: No space left on device` when building APK.

```sh
$ du -sh /usr/share/dotnet
4.0G    /usr/share/dotnet

$ du -sh /usr/local/.ghcup
6.4G    /usr/local/.ghcup

$ du -sh /opt/hostedtoolcache/CodeQL
1.7G    /opt/hostedtoolcache/CodeQL

$ du -sh /usr/share/swift
3.2G    /usr/share/swift

$ du -sh /usr/local/julia*
1015M   /usr/local/julia1.12.2
```

Running those we've got

```sh
# before
$ df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   55G   18G  76% /
# after
$ df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   39G   34G  54% /
```

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

actions/runner-images#2840

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
