### PR TITLE
refactor: remove checkNew timeline update detection

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/entry-column/context/EntriesContext.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/context/EntriesContext.tsx
@@ -15,7 +15,6 @@ type EntriesStateContextValue = {
   isLoading: boolean
   error: unknown | null
   view: FeedViewType
-  hasUpdate: boolean
   fetchedTime?: number
 }
 
@@ -112,7 +111,6 @@ export const EntriesProvider: React.FC<React.PropsWithChildren> = ({ children })
       isLoading: entries.isLoading,
       error: entries.error ?? null,
       view: view!,
-      hasUpdate: entries.hasUpdate,
       fetchedTime: entries.fetchedTime,
     }),
     [entries, view, syncType],

--- a/apps/desktop/layer/renderer/src/modules/entry-column/hooks/useLocalEntries.ts
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/hooks/useLocalEntries.ts
@@ -131,7 +131,6 @@ export const useLocalEntries = ({
   return {
     entriesIds: entries,
     hasNext,
-    hasUpdate: false,
     refetch,
     fetchNextPage,
     isLoading: false,

--- a/apps/desktop/layer/renderer/src/modules/entry-column/index.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/index.tsx
@@ -166,11 +166,7 @@ function EntryColumnContent() {
         !state.error &&
         (!feed || feed?.type === "feed") && <AddFeedHelper />}
 
-      <EntryListHeader
-        refetch={actions.refetch}
-        isRefreshing={isRefreshing}
-        hasUpdate={state.hasUpdate}
-      />
+      <EntryListHeader refetch={actions.refetch} isRefreshing={isRefreshing} />
 
       <EntryColumnWrapper onScroll={handleCombinedScroll} key={`${routeFeedId}-${view}`}>
         {entriesIds.length === 0 ? (

--- a/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/layouts/EntryListHeader.tsx
@@ -43,8 +43,7 @@ import { SwitchToMasonryButton } from "./buttons/SwitchToMasonryButton"
 export const EntryListHeader: FC<{
   refetch: () => void
   isRefreshing: boolean
-  hasUpdate: boolean
-}> = ({ refetch, isRefreshing, hasUpdate }) => {
+}> = ({ refetch, isRefreshing }) => {
   const routerParams = useRouteParams()
   const { t } = useTranslation()
 
@@ -196,19 +195,12 @@ export const EntryListHeader: FC<{
                 </ActionButton>
               ) : (
                 <ActionButton
-                  tooltip={
-                    hasUpdate
-                      ? t("entry_list_header.new_entries_available")
-                      : t("entry_list_header.refetch")
-                  }
+                  tooltip={t("entry_list_header.refetch")}
                   onClick={() => {
                     refetch()
                   }}
                 >
-                  <RotatingRefreshIcon
-                    className={cn(hasUpdate && "text-accent")}
-                    isRefreshing={isRefreshing}
-                  />
+                  <RotatingRefreshIcon isRefreshing={isRefreshing} />
                 </ActionButton>
               ))}
             {!isCollection && (

--- a/apps/desktop/layer/renderer/src/queries/entries.ts
+++ b/apps/desktop/layer/renderer/src/queries/entries.ts
@@ -1,6 +1,5 @@
 import { followClient } from "~/lib/api-client"
 import { defineQuery } from "~/lib/defineQuery"
-import { getEntriesParams } from "~/lib/utils"
 
 export const entries = {
   preview: (id: string) =>
@@ -15,53 +14,6 @@ export const entries = {
       },
       {
         rootKey: ["entries-preview"],
-      },
-    ),
-
-  checkNew: ({
-    feedId,
-    inboxId,
-    listId,
-    view,
-    read,
-    fetchedTime,
-  }: {
-    feedId?: number | string
-    inboxId?: number | string
-    listId?: number | string
-    view?: number
-    read?: boolean
-    fetchedTime: number
-  }) =>
-    defineQuery(
-      ["entry-checkNew", inboxId || listId || feedId, view, read, fetchedTime],
-      async () => {
-        const query = {
-          ...getEntriesParams({
-            feedId,
-            inboxId,
-            listId,
-            view,
-          }),
-          read,
-          insertedAfter: fetchedTime,
-        }
-
-        if (query.feedIdList && query.feedIdList.length === 1) {
-          query.feedId = query.feedIdList[0]
-          delete query.feedIdList
-        }
-        return followClient.api.entries.checkNew({
-          insertedAfter: query.insertedAfter,
-          view: query.view,
-          feedId: query.feedId,
-          read: typeof query.read === "boolean" ? query.read : undefined,
-          feedIdList: query.feedIdList,
-        })
-      },
-
-      {
-        rootKey: ["entry-checkNew", inboxId || listId || feedId],
       },
     ),
 }

--- a/apps/mobile/src/modules/screen/atoms.ts
+++ b/apps/mobile/src/modules/screen/atoms.ts
@@ -186,7 +186,6 @@ function useRemoteEntries(props?: UseEntriesProps): UseEntriesReturn {
   return {
     entriesIds: query.entriesIds,
     hasNext: query.hasNextPage,
-    hasUpdate: false,
     refetch,
     fetchNextPage,
     isLoading: query.isFetching,
@@ -299,7 +298,6 @@ function useLocalEntries(props?: UseEntriesProps): UseEntriesReturn {
   return {
     entriesIds: entries,
     hasNext,
-    hasUpdate: false,
     refetch,
     fetchNextPage,
     isLoading: false,

--- a/locales/app/en.json
+++ b/locales/app/en.json
@@ -201,7 +201,6 @@
   "entry_list_header.items": "items",
   "entry_list_header.masonry": "Masonry",
   "entry_list_header.masonry_column": "Masonry Column",
-  "entry_list_header.new_entries_available": "New entries available",
   "entry_list_header.preview_mode": "Preview Mode",
   "entry_list_header.refetch": "Refetch",
   "entry_list_header.refresh": "Refresh",

--- a/locales/app/ja.json
+++ b/locales/app/ja.json
@@ -200,7 +200,6 @@
   "entry_list_header.items": "項目",
   "entry_list_header.masonry": "メイソンリー",
   "entry_list_header.masonry_column": "メイソンリー列",
-  "entry_list_header.new_entries_available": "新しいエントリーが利用可能です",
   "entry_list_header.preview_mode": "プレビューモード",
   "entry_list_header.refetch": "再取得",
   "entry_list_header.refresh": "更新",

--- a/locales/app/zh-CN.json
+++ b/locales/app/zh-CN.json
@@ -200,7 +200,6 @@
   "entry_list_header.items": "内容",
   "entry_list_header.masonry": "瀑布流布局",
   "entry_list_header.masonry_column": "布局列数",
-  "entry_list_header.new_entries_available": "有新内容",
   "entry_list_header.preview_mode": "预览模式",
   "entry_list_header.refetch": "刷新",
   "entry_list_header.refresh": "刷新",

--- a/locales/app/zh-TW.json
+++ b/locales/app/zh-TW.json
@@ -191,7 +191,6 @@
   "entry_list_header.items": "內容",
   "entry_list_header.masonry": "瀑布式佈局",
   "entry_list_header.masonry_column": "佈局列數",
-  "entry_list_header.new_entries_available": "有新內容",
   "entry_list_header.preview_mode": "預覽模式",
   "entry_list_header.refetch": "重新獲取",
   "entry_list_header.refresh": "重新整理",

--- a/packages/internal/store/src/modules/entry/types.ts
+++ b/packages/internal/store/src/modules/entry/types.ts
@@ -29,7 +29,6 @@ export type UseEntriesProps = {
 export type UseEntriesReturn = {
   entriesIds: string[]
   hasNext: boolean
-  hasUpdate: boolean
   refetch: () => Promise<void>
   fetchNextPage: () => Promise<void> | void
   isLoading: boolean

--- a/packages/internal/store/src/modules/entry/utils.ts
+++ b/packages/internal/store/src/modules/entry/utils.ts
@@ -63,7 +63,6 @@ export function isInboxEntry(entry?: { inboxHandle?: string | null }) {
 export const fallbackReturn: UseEntriesReturn = {
   entriesIds: [],
   hasNext: false,
-  hasUpdate: false,
   refetch: async () => {},
 
   fetchNextPage: async () => {},


### PR DESCRIPTION
## Description

Remove the checkNew API query and related state management that periodically checked for new entries in the timeline. This simplifies the entry management logic by eliminating the hasUpdate state and the refresh button highlighting feature.

## Changes

- Removed checkNew query from entries API
- Removed hasUpdate state and related effects
- Removed "new entries available" UI indication
- Preserved fetchedTime for mark-all-read filtering
- Cleaned up related translations

## Type

- [x] Refactor