### PR TITLE
fix: shortcuts page freeze

### DIFF
--- a/packages/configs/tailwindcss/tailwind-extend.css
+++ b/packages/configs/tailwindcss/tailwind-extend.css
@@ -92,7 +92,6 @@
       rgba(var(--color-background) / 0.95),
       rgba(var(--color-background) / 0.92)
     );
-    backdrop-filter: blur(12px);
     @apply rounded-[4px] px-1 text-[0.5em];
     @apply inline-flex items-center justify-center;
     box-shadow:


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
<img width="1088" height="841" alt="1Capture_2026-01-24_17 21 07" src="https://github.com/user-attachments/assets/65e1c8fe-0daa-411f-9d61-17d844964bdc" />

**preferences -> shortcuts page freeze**
I found that it was a style issue with the Kbd component
the problematic style is `backdrop-filter: blur(12px);`;
this style will create a GPU compositing layer, which will frequently trigger recomposition during scrolling/reflow, resulting in performance issues.
so I deleted this style

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
