### PR TITLE
fix: handle invalid URL parsing in useFeedSafeUrl hook

### DIFF
--- a/apps/desktop/layer/renderer/src/hooks/common/useFeedSafeUrl.ts
+++ b/apps/desktop/layer/renderer/src/hooks/common/useFeedSafeUrl.ts
@@ -31,8 +31,12 @@ export const useFeedSafeUrl = (entryId: string) => {
     }
 
     if (href.startsWith("http")) {
-      const domain = new URL(href).hostname
-      if (domain === "localhost") return null
+      try {
+        const domain = new URL(href).hostname
+        if (domain === "localhost") return null
+      } catch {
+        return null
+      }
 
       return href
     }


### PR DESCRIPTION
Wrap new URL() constructor in try-catch to gracefully handle malformed URL strings that start with 'http' but are invalid. Returns null instead of throwing TypeError.

This fixes the 'Failed to construct URL: Invalid URL' error that was occurring in the useFeedSafeUrl hook when processing certain malformed URLs.