### PR TITLE
feat: add desktop-release skill for regular version releases

### DIFF
--- a/.claude/skills/desktop-release/SKILL.md
+++ b/.claude/skills/desktop-release/SKILL.md
@@ -107,13 +107,17 @@ Present your analysis to the user with:
 
 If Step 3 decided mainHash should NOT be updated, restore the old value now. The bump has already committed, pushed, and created the PR on a new release branch, so we amend the commit and force push. This is safe because the release branch was just created.
 
-1. Ensure you are on the `release/desktop/{NEW_VERSION}` branch (bump should have switched to it).
-2. Replace the recalculated mainHash with the saved old value in `apps/desktop/package.json`.
-3. Stage and amend the release commit:
+1. Change back to the repo root first (Step 4 left the working directory at `apps/desktop/`):
+   ```bash
+   cd ../..
+   ```
+2. Ensure you are on the `release/desktop/{NEW_VERSION}` branch (bump should have switched to it).
+3. Replace the recalculated mainHash with the saved old value in `apps/desktop/package.json`.
+4. Stage and amend the release commit:
    ```bash
    git add apps/desktop/package.json && git commit --amend --no-edit
    ```
-4. Force push the release branch:
+5. Force push the release branch:
    ```bash
    git push --force origin release/desktop/{NEW_VERSION}
    ```


### PR DESCRIPTION
## Summary

Add a comprehensive skill for performing regular desktop releases from the dev branch. The skill automates the release workflow while focusing on the critical decision: whether to update mainHash.

## What it does

- Gathers commits since last release and categorizes them (features, improvements, fixes)
- Updates changelog with user confirmation
- **Evaluates mainHash impact**: Analyzes changes to `layer/main/` to determine if users need full app updates or can use lightweight renderer hot updates
- Executes version bump with optional mainHash skip for faster renderer-only updates when appropriate
- Creates release PR to main branch

## Key insight

mainHash changes don't always require application updates. If the main process code hasn't changed, users can enjoy fast renderer-only hot updates. This skill guides the decision with clear analysis and user confirmation.

## Testing

The skill includes detailed instructions for all release phases and properly handles the conditional mainHash update logic based on actual code changes.