### PR TITLE
fix(mobile): migrate to ReanimatedSwipeable and upgrade react-native-css-interop

### DIFF
--- a/apps/mobile/src/components/common/SwipeableItem.tsx
+++ b/apps/mobile/src/components/common/SwipeableItem.tsx
@@ -1,10 +1,18 @@
-import { useTypeScriptHappyCallback } from "@follow/hooks"
 import { impactAsync, ImpactFeedbackStyle } from "expo-haptics"
 import { atom, useAtomValue, useSetAtom } from "jotai"
 import { selectAtom } from "jotai/utils"
 import * as React from "react"
-import { Animated, StyleSheet, View } from "react-native"
-import { RectButton, Swipeable } from "react-native-gesture-handler"
+import { StyleSheet, View } from "react-native"
+import { RectButton } from "react-native-gesture-handler"
+import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable"
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable"
+import type { SharedValue } from "react-native-reanimated"
+import Animated, {
+  interpolate,
+  runOnJS,
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from "react-native-reanimated"
 
 import { Text } from "@/src/components/ui/typography/Text"
 
@@ -51,9 +59,9 @@ export const SwipeableItem: React.FC<SwipeableItemProps> = ({
   disabled,
   swipeRightToCallAction,
 }) => {
-  const itemRef = React.useRef<Swipeable | null>(null)
+  const itemRef = React.useRef<SwipeableMethods | null>(null)
   const endDragCallerRef = React.useRef<() => void>(() => {})
-  const renderLeftActions = (progress: Animated.AnimatedInterpolation<number>) => {
+  const renderLeftActions = (progress: SharedValue<number>) => {
     const width = leftActions?.length ? leftActions.length * rectButtonWidth : rectButtonWidth
     return (
       <>
@@ -73,56 +81,20 @@ export const SwipeableItem: React.FC<SwipeableItemProps> = ({
             },
           ]}
         >
-          {leftActions?.map((action, index) => {
-            const trans = progress.interpolate({
-              inputRange: [0, 1],
-              outputRange: [-rectButtonWidth * (leftActions?.length ?? 1), 0],
-            })
-            return (
-              <Animated.View
-                key={index}
-                style={[
-                  styles.animatedContainer,
-                  {
-                    transform: [
-                      {
-                        translateX: trans,
-                      },
-                    ],
-                    width: rectButtonWidth,
-                    left: index * rectButtonWidth,
-                  },
-                ]}
-              >
-                <RectButton
-                  style={[
-                    styles.actionContainer,
-                    {
-                      backgroundColor: action.backgroundColor ?? "#fff",
-                    },
-                  ]}
-                  onPress={action.onPress}
-                >
-                  {action.icon}
-                  <Text
-                    style={[
-                      styles.actionText,
-                      {
-                        color: action.color ?? "#fff",
-                      },
-                    ]}
-                  >
-                    {action.label}
-                  </Text>
-                </RectButton>
-              </Animated.View>
-            )
-          })}
+          {leftActions?.map((action, index) => (
+            <LeftActionItem
+              key={index}
+              index={index}
+              action={action}
+              progress={progress}
+              length={leftActions?.length ?? 1}
+            />
+          ))}
         </Animated.View>
       </>
     )
   }
-  const renderRightActions = (progress: Animated.AnimatedInterpolation<number>) => {
+  const renderRightActions = (progress: SharedValue<number>, translation: SharedValue<number>) => {
     const width = rightActions?.length ? rightActions.length * rectButtonWidth : rectButtonWidth
     return (
       <>
@@ -151,6 +123,7 @@ export const SwipeableItem: React.FC<SwipeableItemProps> = ({
                 action={action}
                 length={rightActions?.length ?? 1}
                 progress={progress}
+                translation={translation}
                 swipeRightToCallAction={
                   swipeRightToCallAction && index === rightActions?.length - 1
                 }
@@ -176,22 +149,20 @@ export const SwipeableItem: React.FC<SwipeableItemProps> = ({
     }
   }, [isOpened])
   return (
-    <Swipeable
+    <ReanimatedSwipeable
       ref={itemRef}
       enabled={!disabled}
       friction={1}
       onSwipeableWillOpen={() => {
         setAtom(id)
+        if (swipeRightToCallAction && endDragCallerRef.current) {
+          endDragCallerRef.current()
+          endDragCallerRef.current = () => {}
+        }
       }}
       leftThreshold={37}
       rightThreshold={37}
       enableTrackpadTwoFingerGesture
-      useNativeAnimations
-      onEnded={useTypeScriptHappyCallback(() => {
-        if (swipeRightToCallAction && endDragCallerRef.current) {
-          endDragCallerRef.current()
-        }
-      }, [swipeRightToCallAction, endDragCallerRef])}
       renderLeftActions={leftActions?.length ? renderLeftActions : undefined}
       renderRightActions={rightActions?.length ? renderRightActions : undefined}
       overshootLeft={leftActions?.length ? leftActions?.length >= 1 : undefined}
@@ -199,7 +170,7 @@ export const SwipeableItem: React.FC<SwipeableItemProps> = ({
       overshootFriction={swipeRightToCallAction ? 1 : 10}
     >
       {children}
-    </Swipeable>
+    </ReanimatedSwipeable>
   )
 }
 const SwipeableGroupContext = React.createContext({
@@ -214,6 +185,63 @@ export const SwipeableGroupProvider = ({ children }: { children: React.ReactNode
   )
   return <SwipeableGroupContext value={ctx}>{children}</SwipeableGroupContext>
 }
+
+const LeftActionItem = React.memo(
+  ({
+    index,
+    action,
+    progress,
+    length = 1,
+  }: {
+    index: number
+    action: Action
+    progress: SharedValue<number>
+    length: number
+  }) => {
+    const animStyle = useAnimatedStyle(() => ({
+      transform: [
+        {
+          translateX: interpolate(progress.value, [0, 1], [-rectButtonWidth * length, 0]),
+        },
+      ],
+    }))
+    return (
+      <Animated.View
+        style={[
+          styles.animatedContainer,
+          {
+            width: rectButtonWidth,
+            left: index * rectButtonWidth,
+          },
+          animStyle,
+        ]}
+      >
+        <RectButton
+          style={[
+            styles.actionContainer,
+            {
+              backgroundColor: action.backgroundColor ?? "#fff",
+            },
+          ]}
+          onPress={action.onPress}
+        >
+          {action.icon}
+          <Text
+            style={[
+              styles.actionText,
+              {
+                color: action.color ?? "#fff",
+              },
+            ]}
+          >
+            {action.label}
+          </Text>
+        </RectButton>
+      </Animated.View>
+    )
+  },
+)
+
 const rightActionThreshold = -100
 const RightRectButton = React.memo(
   ({
@@ -221,66 +249,72 @@ const RightRectButton = React.memo(
     action,
     length = 1,
     progress,
+    translation,
     swipeRightToCallAction,
     endDragCallerRef,
   }: {
-    progress: Animated.AnimatedInterpolation<number>
+    progress: SharedValue<number>
+    translation: SharedValue<number>
     index: number
     action: Action
     length: number
     swipeRightToCallAction?: boolean
     endDragCallerRef: React.MutableRefObject<() => void>
   }) => {
-    const trans = React.useMemo(
-      () =>
-        progress.interpolate({
-          inputRange: [0, 1, 1.2],
-          outputRange: [rectButtonWidth * length, 0, -40],
-        }),
-      [progress, length],
-    )
-    const parallaxX = React.useMemo(
-      () =>
-        progress.interpolate({
-          inputRange: [0, 1, 1.2],
-          outputRange: [0, 0, 10],
-        }),
-      [progress],
-    )
     const hapticOnce = React.useRef(false)
-    React.useEffect(() => {
-      if (!swipeRightToCallAction) return
-      const id = trans.addListener(({ value }) => {
-        if (value <= rightActionThreshold) {
-          if (hapticOnce.current) return
-          hapticOnce.current = true
-          impactAsync(ImpactFeedbackStyle.Light)
-          endDragCallerRef.current = () => {
-            action.onPress?.()
+
+    const setEndDragCaller = React.useCallback(
+      (shouldCall: boolean) => {
+        if (shouldCall) {
+          if (!hapticOnce.current) {
+            hapticOnce.current = true
+            impactAsync(ImpactFeedbackStyle.Light)
+            endDragCallerRef.current = () => {
+              action.onPress?.()
+            }
           }
         } else {
           hapticOnce.current = false
           endDragCallerRef.current = () => {}
         }
-      })
-      return () => {
-        trans.removeListener(id)
-      }
-    }, [action, endDragCallerRef, swipeRightToCallAction, trans])
+      },
+      [action, endDragCallerRef],
+    )
+
+    useAnimatedReaction(
+      () => translation.value,
+      (value) => {
+        if (!swipeRightToCallAction) return
+        runOnJS(setEndDragCaller)(value <= rightActionThreshold)
+      },
+      [swipeRightToCallAction, setEndDragCaller],
+    )
+
+    const animStyle = useAnimatedStyle(() => ({
+      transform: [
+        {
+          translateX: interpolate(progress.value, [0, 1, 1.2], [rectButtonWidth * length, 0, -40]),
+        },
+      ],
+    }))
+
+    const textAnimStyle = useAnimatedStyle(() => ({
+      transform: [
+        {
+          translateX: interpolate(progress.value, [0, 1, 1.2], [0, 0, 10]),
+        },
+      ],
+    }))
+
     return (
       <Animated.View
-        key={index}
         style={[
           styles.animatedContainer,
           {
-            transform: [
-              {
-                translateX: trans,
-              },
-            ],
             width: rectButtonWidth,
             left: index * rectButtonWidth,
           },
+          animStyle,
         ]}
       >
         <RectButton
@@ -299,13 +333,7 @@ const RightRectButton = React.memo(
               {
                 color: action.color ?? "#fff",
               },
-              {
-                transform: [
-                  {
-                    translateX: parallaxX,
-                  },
-                ],
-              },
+              textAnimStyle,
             ]}
           >
             {action.label}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,24 +20,24 @@ catalogs:
       version: 5.9.3
 
 overrides:
-  '@react-native-menu/menu': 2.0.0
-  drizzle-orm: 0.45.1
   '@electron/node-gyp': 10.2.0-electron.2
-  '@types/react': 19.1.17
   '@floating-ui/core': 1.7.2
   '@floating-ui/dom': 1.7.2
   '@floating-ui/react': 0.27.14
   '@floating-ui/react-dom': 2.1.4
+  '@react-native-menu/menu': 2.0.0
+  '@types/react': 19.1.17
+  drizzle-orm: 0.45.1
+  global-agent>serialize-error: 7.0.1
   is-core-module: npm:@nolyfill/is-core-module@1.0.39
   isarray: npm:@nolyfill/isarray@1.0.44
   lan-network@<0.1.7: 0.1.7
-  nativewind>react-native-css-interop: 0.1.22
+  nativewind>react-native-css-interop: 0.2.1
   react: 19.1.0
   react-dom: 19.1.0
   react-native-ios-context-menu: 3.2.1
   react-native-ios-utilities: 5.2.0
   serialize-error: 2.1.0
-  global-agent>serialize-error: 7.0.1
 
 patchedDependencies:
   '@microflash/remark-callout-directives':
@@ -9939,6 +9939,11 @@ packages:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
 
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -12654,10 +12659,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-darwin-arm64@1.27.0:
+    resolution: {integrity: sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   lightningcss-darwin-arm64@1.31.1:
     resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.27.0:
+    resolution: {integrity: sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.31.1:
@@ -12666,11 +12683,23 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-freebsd-x64@1.27.0:
+    resolution: {integrity: sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   lightningcss-freebsd-x64@1.31.1:
     resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.27.0:
+    resolution: {integrity: sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
 
   lightningcss-linux-arm-gnueabihf@1.31.1:
     resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
@@ -12678,8 +12707,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm64-gnu@1.27.0:
+    resolution: {integrity: sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.31.1:
     resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.27.0:
+    resolution: {integrity: sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -12690,8 +12731,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-x64-gnu@1.27.0:
+    resolution: {integrity: sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.27.0:
+    resolution: {integrity: sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -12702,10 +12755,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-win32-arm64-msvc@1.27.0:
+    resolution: {integrity: sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.27.0:
+    resolution: {integrity: sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.31.1:
@@ -12713,6 +12778,10 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
+
+  lightningcss@1.27.0:
+    resolution: {integrity: sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.31.1:
     resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
@@ -14765,8 +14834,8 @@ packages:
       react: 19.1.0
       react-native: '*'
 
-  react-native-css-interop@0.1.22:
-    resolution: {integrity: sha512-Mu01e+H9G+fxSWvwtgWlF5MJBJC4VszTCBXopIpeR171lbeBInHb8aHqoqRPxmJpi3xIHryzqKFOJYAdk7PBxg==}
+  react-native-css-interop@0.2.1:
+    resolution: {integrity: sha512-B88f5rIymJXmy1sNC/MhTkb3xxBej1KkuAt7TiT9iM7oXz3RM8Bn+7GUrfR02TvSgKm4cg2XiSuLEKYfKwNsjA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 19.1.0
@@ -27623,6 +27692,8 @@ snapshots:
 
   detect-indent@7.0.2: {}
 
+  detect-libc@1.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-newline@4.0.1: {}
@@ -31138,35 +31209,80 @@ snapshots:
   lightningcss-android-arm64@1.31.1:
     optional: true
 
+  lightningcss-darwin-arm64@1.27.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.27.0:
     optional: true
 
   lightningcss-darwin-x64@1.31.1:
     optional: true
 
+  lightningcss-freebsd-x64@1.27.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.27.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.31.1:
     optional: true
 
+  lightningcss-linux-arm64-gnu@1.27.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.31.1:
     optional: true
 
+  lightningcss-linux-x64-gnu@1.27.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.27.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.31.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.27.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.27.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.31.1:
     optional: true
+
+  lightningcss@1.27.0:
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.27.0
+      lightningcss-darwin-x64: 1.27.0
+      lightningcss-freebsd-x64: 1.27.0
+      lightningcss-linux-arm-gnueabihf: 1.27.0
+      lightningcss-linux-arm64-gnu: 1.27.0
+      lightningcss-linux-arm64-musl: 1.27.0
+      lightningcss-linux-x64-gnu: 1.27.0
+      lightningcss-linux-x64-musl: 1.27.0
+      lightningcss-win32-arm64-msvc: 1.27.0
+      lightningcss-win32-x64-msvc: 1.27.0
 
   lightningcss@1.31.1:
     dependencies:
@@ -32251,7 +32367,7 @@ snapshots:
     dependencies:
       comment-json: 4.2.5
       debug: 4.4.3(supports-color@8.1.1)
-      react-native-css-interop: 0.1.22(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
+      react-native-css-interop: 0.2.1(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
     transitivePeerDependencies:
       - react
@@ -33461,13 +33577,13 @@ snapshots:
       rn-color-matrices: 4.1.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))
       ts-tiny-invariant: 2.0.5
 
-  react-native-css-interop@0.1.22(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
+  react-native-css-interop@0.2.1(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
-      lightningcss: 1.31.1
+      lightningcss: 1.27.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5)
       react-native-reanimated: 4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)(utf-8-validate@6.0.5))(react@19.1.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,12 +15,6 @@ catalog:
 
 ignorePatchFailures: false
 
-# minimumReleaseAge: 1440
-
-# minimumReleaseAgeExclude:
-#   - "@follow-app/*"
-#   - "@folo-services/*"
-
 onlyBuiltDependencies:
   - "@firebase/util"
   - "@sentry/cli"
@@ -42,24 +36,24 @@ onlyBuiltDependencies:
   - utf-8-validate
 
 overrides:
-  "@react-native-menu/menu": 2.0.0
-  drizzle-orm: 0.45.1
   "@electron/node-gyp": 10.2.0-electron.2
-  "@types/react": 19.1.17
   "@floating-ui/core": 1.7.2
   "@floating-ui/dom": 1.7.2
   "@floating-ui/react": 0.27.14
   "@floating-ui/react-dom": 2.1.4
+  "@react-native-menu/menu": 2.0.0
+  "@types/react": 19.1.17
+  drizzle-orm: 0.45.1
+  global-agent>serialize-error: 7.0.1
   is-core-module: npm:@nolyfill/is-core-module@1.0.39
   isarray: npm:@nolyfill/isarray@1.0.44
   lan-network@<0.1.7: 0.1.7
-  nativewind>react-native-css-interop: 0.1.22
+  nativewind>react-native-css-interop: 0.2.1
   react: 19.1.0
   react-dom: 19.1.0
   react-native-ios-context-menu: 3.2.1
   react-native-ios-utilities: 5.2.0
   serialize-error: 2.1.0
-  global-agent>serialize-error: 7.0.1
 
 patchedDependencies:
   "@microflash/remark-callout-directives": patches/@microflash__remark-callout-directives.patch


### PR DESCRIPTION
## Summary

- Migrate SwipeableItem from deprecated Swipeable (old PanGestureHandler API) to ReanimatedSwipeable (new Reanimated-integrated API)
- Replace React Native Animated with react-native-reanimated APIs
- Upgrade react-native-css-interop from 0.1.22 to 0.2.1 (fixes React 19 compatibility issue)

## Motivation

Fixes React 19 + React Native 0.81 compatibility issues:
1. Old Swipeable API uses `findNodeHandle()` which doesn't work with React 19's ref-as-prop model
2. NativeWind's old version had incompatible ref checks for function components
3. RN Animated API conflicts with Reanimated animations in newer versions

## Changes

**SwipeableItem.tsx:**
- Switched from `Swipeable` to `ReanimatedSwipeable`
- Converted animation system from RN Animated to Reanimated (SharedValue, useAnimatedStyle, interpolate)
- Extracted LeftActionItem component to properly use hooks
- Replaced `trans.addListener()` with `useAnimatedReaction()` for translation monitoring

**Dependencies:**
- react-native-css-interop 0.1.22 → 0.2.1

This fixes the "[Gesture Handler] Failed to obtain view for PanGestureHandler" error and the "animation style to function component" error that appeared after login in mobile.