### PR TITLE
fix(mobile): keep preview login token and asset fallback build

### DIFF
--- a/apps/mobile/plugins/with-follow-assets.js
+++ b/apps/mobile/plugins/with-follow-assets.js
@@ -20,10 +20,11 @@ const isAssetReady = (assetsPath) => {
 
 const withFollowAssets = (config, props) => {
   if (!isAssetReady(props.assetsPath)) {
-    // TODO move to props
-    const cmd = `pnpm --filter @follow/rn-micro-web-app build --outDir ${path.resolve(props.assetsPath, "html-renderer")}`
+    // Build the web renderer directly to avoid workspace filter resolution issues on EAS workers.
+    const webAppDir = path.resolve(__dirname, "..", "web-app")
+    const cmd = `pnpm --dir ${webAppDir} build --outDir ${path.resolve(props.assetsPath, "html-renderer")}`
     console.info(`Assets source directory not found! Running \`${cmd}\` to generate assets.`)
-    execSync(cmd)
+    execSync(cmd, { stdio: "inherit" })
   }
   if (!isAssetReady(props.assetsPath)) {
     throw new Error(

--- a/apps/mobile/src/lib/token.ts
+++ b/apps/mobile/src/lib/token.ts
@@ -9,12 +9,10 @@ export async function getTokenHeaders() {
     const appCheckToken = await getLimitedUseToken(appCheck)
     token = appCheckToken.token
   } catch (error) {
-    console.error("error", error)
+    console.warn("[app-check] failed to get limited-use token, fallback to synthetic token", error)
   }
 
-  return token
-    ? {
-        "x-token": `ac:${token}`,
-      }
-    : undefined
+  return {
+    "x-token": `ac:${token || "fallback"}`,
+  }
 }


### PR DESCRIPTION
### Description

- Ensure mobile preview login always sends `x-token` by falling back to `ac:fallback` when App Check token retrieval fails.
- Fix EAS fallback web asset generation to build from `apps/mobile/web-app` via `pnpm --dir`, with inherited stdio for clearer build diagnostics.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

Please focus review on preview login request headers and EAS fallback asset generation path.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
