### PR TITLE
fix(mobile): smooth iOS timeline selector indicator

### DIFF
--- a/apps/mobile/native/ios/Modules/PagerView/EnhancePagerController.swift
+++ b/apps/mobile/native/ios/Modules/PagerView/EnhancePagerController.swift
@@ -114,7 +114,6 @@ class EnhancePagerController: UIPageViewController, UIScrollViewDelegate {
 
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     startOffset = scrollView.contentOffset.x
-    debugPrint(scrollView.contentOffset.x)
     isDragging = true
     onScrollStart?(currentPageIndex)
   }
@@ -128,12 +127,14 @@ class EnhancePagerController: UIPageViewController, UIScrollViewDelegate {
       direction = .left
     }
 
+    guard view.frame.width > 0 else { return }
     let positionFromStartOfCurrentPage = abs(startOffset - scrollView.contentOffset.x)
     let percent = positionFromStartOfCurrentPage / view.frame.width
     let position = currentPageIndex
 
-    debugPrint(percent, direction, position)
-    onScroll?(percent, direction, position)
+    if direction != .none || percent > 0 {
+      onScroll?(percent, direction, position)
+    }
   }
 
   public func scrollViewDidEndDragging(

--- a/apps/mobile/native/ios/Modules/PagerView/EnhancePagerViewModule.swift
+++ b/apps/mobile/native/ios/Modules/PagerView/EnhancePagerViewModule.swift
@@ -68,6 +68,7 @@ enum TransitionStyle: String, Enumerable {
 
 private class EnhancePagerView: ExpoView, UIGestureRecognizerDelegate {
   fileprivate var pageController: EnhancePagerController?
+  private var isInitialized = false
 
   private let onScroll = EventDispatcher()
   private let onScrollBegin = EventDispatcher()
@@ -104,6 +105,11 @@ private class EnhancePagerView: ExpoView, UIGestureRecognizerDelegate {
   var transitionStyle: TransitionStyle = .scroll
   var panGestureRecognizer: UIGestureRecognizer?
   func initialize() {
+    if isInitialized {
+      return
+    }
+    isInitialized = true
+
     let panGestureRecognizer = UIPanGestureRecognizer()
     panGestureRecognizer.delegate = self
     self.panGestureRecognizer = panGestureRecognizer


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR improves iOS timeline selector animation smoothness when switching views. It removes per-frame native pager debug logs, adds guards for invalid/idle scroll events, and prevents duplicate native pager initialization. It also deduplicates tiny `dragProgress` updates in `PagerList.ios.tsx` to avoid redundant animation writes. Together these changes reduce jank in the top view indicator during swipe and programmatic tab switches.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

No functional behavior change is intended; this only optimizes the iOS pager/indicator update path.

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
