### PR TITLE
fix(ci): stabilize release workflows and parallel desktop builds

### DIFF
--- a/.claude/skills/desktop-release/SKILL.md
+++ b/.claude/skills/desktop-release/SKILL.md
@@ -60,7 +60,21 @@ Perform a regular desktop release. This skill handles the full release workflow 
 
 5. Keep `NEXT_VERSION` as the placeholder - it will be replaced by `apply-changelog.ts` during bump.
 
-## Step 3: Evaluate mainHash
+## Step 3: Commit changelog updates before bump
+
+`nbump` requires a clean working tree. Commit changelog edits before running bump.
+
+1. Stage the changelog update:
+   ```bash
+   git add apps/desktop/changelog/next.md
+   ```
+2. Commit it on `dev`:
+   ```bash
+   git commit -m "docs(desktop): prepare release changelog"
+   ```
+3. If there are no changes to commit, continue without creating an extra commit.
+
+## Step 4: Evaluate mainHash
 
 This is critical for determining whether users need a full app update or can use the lightweight renderer hot update.
 
@@ -86,14 +100,18 @@ Present your analysis to the user with:
 - Your recommendation (update or skip mainHash)
 - Ask for explicit confirmation
 
-## Step 4: Save old mainHash and execute bump
+## Step 5: Save old mainHash and execute bump
 
 1. Save the current mainHash from `apps/desktop/package.json` for later comparison.
-2. Change directory to `apps/desktop/` and run the bump:
+2. Verify working tree is clean before bump:
+   ```bash
+   git status --short
+   ```
+3. Change directory to `apps/desktop/` and run the bump:
    ```bash
    cd apps/desktop && pnpm bump
    ```
-3. This command will:
+4. This command will:
    - Pull latest changes
    - Apply changelog (rename next.md to {version}.md, create new next.md)
    - Recalculate mainHash and write to package.json
@@ -103,11 +121,11 @@ Present your analysis to the user with:
    - Create branch `release/desktop/{NEW_VERSION}`
    - Push branch and create PR to `main`
 
-## Step 5: Restore mainHash if skipping update
+## Step 6: Restore mainHash if skipping update
 
-If Step 3 decided mainHash should NOT be updated, restore the old value now. The bump has already committed, pushed, and created the PR on a new release branch, so we amend the commit and force push. This is safe because the release branch was just created.
+If Step 4 decided mainHash should NOT be updated, restore the old value now. The bump has already committed, pushed, and created the PR on a new release branch, so we amend the commit and force push. This is safe because the release branch was just created.
 
-1. Change back to the repo root first (Step 4 left the working directory at `apps/desktop/`):
+1. Change back to the repo root first (Step 5 left the working directory at `apps/desktop/`):
    ```bash
    cd ../..
    ```
@@ -122,9 +140,9 @@ If Step 3 decided mainHash should NOT be updated, restore the old value now. The
    git push --force origin release/desktop/{NEW_VERSION}
    ```
 
-If Step 3 decided mainHash SHOULD be updated, skip this step entirely — the bump already wrote the correct new value.
+If Step 4 decided mainHash SHOULD be updated, skip this step entirely — the bump already wrote the correct new value.
 
-## Step 6: Verify
+## Step 7: Verify
 
 1. Confirm the PR was created successfully by checking the output.
 2. Report the new version number and PR URL to the user.

--- a/.claude/skills/mobile-release/SKILL.md
+++ b/.claude/skills/mobile-release/SKILL.md
@@ -64,13 +64,31 @@ Perform a regular mobile release. This skill handles the full release workflow f
 
 5. Keep `NEXT_VERSION` as the placeholder - it will be replaced by `apply-changelog.ts` during bump.
 
-## Step 3: Execute bump
+## Step 3: Commit changelog updates before bump
 
-1. Change directory to `apps/mobile/` and run the bump:
+`nbump` requires a clean working tree. Commit changelog edits before running bump.
+
+1. Stage the changelog update:
+   ```bash
+   git add apps/mobile/changelog/next.md
+   ```
+2. Commit it on `dev`:
+   ```bash
+   git commit -m "docs(mobile): prepare release changelog"
+   ```
+3. If there are no changes to commit, continue without creating an extra commit.
+
+## Step 4: Execute bump
+
+1. Verify working tree is clean before bump:
+   ```bash
+   git status --short
+   ```
+2. Change directory to `apps/mobile/` and run the bump:
    ```bash
    cd apps/mobile && pnpm bump
    ```
-2. This is an interactive `nbump` command that prompts for version selection. It will:
+3. This is an interactive `nbump` command that prompts for version selection. It will:
    - Pull latest changes
    - Apply changelog (rename next.md to {version}.md, create new next.md from template)
    - Format package.json with eslint + prettier
@@ -82,7 +100,7 @@ Perform a regular mobile release. This skill handles the full release workflow f
    - Create branch `release/mobile/{NEW_VERSION}`
    - Push branch and create PR to `mobile-main`
 
-## Step 4: Verify
+## Step 5: Verify
 
 1. Confirm the PR was created successfully by checking the output.
 2. Report the new version number and PR URL to the user.

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build:
     name: Build Android apk for device
-    if: github.secret_source != 'None' && (github.event_name != 'push' || !startsWith(github.event.head_commit.message || '', 'release(mobile):'))
+    if: github.secret_source != 'None' && (github.event_name != 'push' || !contains(github.event.head_commit.message || '', 'release(mobile):'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -23,7 +23,7 @@ on:
 
 # https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-build
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.tag_version == 'true' && 'tag-version' || github.event.inputs.store == 'true' && 'store' || 'manual') || 'build' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 env:
   VITE_WEB_URL: ${{ vars.VITE_WEB_URL }}
@@ -37,7 +37,7 @@ env:
 
 jobs:
   release:
-    if: github.secret_source != 'None' && (github.event_name != 'push' || !startsWith(github.event.head_commit.message || '', 'release(desktop):'))
+    if: github.secret_source != 'None' && (github.event_name != 'push' || !contains(github.event.head_commit.message || '', 'release(desktop):'))
     runs-on: ${{ matrix.os }}
     env:
       PROD: ${{ github.event.inputs.tag_version == 'true' || github.ref_type == 'tag' || github.event.inputs.store == 'true' }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   check-runner:
-    if: github.secret_source != 'None' && (github.event_name != 'push' || !startsWith(github.event.head_commit.message || '', 'release(mobile):'))
+    if: github.secret_source != 'None' && (github.event_name != 'push' || !contains(github.event.head_commit.message || '', 'release(mobile):'))
     runs-on: ubuntu-latest
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -13,8 +13,8 @@ jobs:
   sync-to-dev:
     runs-on: ubuntu-latest
     if: |
-      (github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'release(desktop):')) ||
-      (github.ref == 'refs/heads/mobile-main' && startsWith(github.event.head_commit.message, 'release(mobile):'))
+      (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message || '', 'release(desktop):')) ||
+      (github.ref == 'refs/heads/mobile-main' && contains(github.event.head_commit.message || '', 'release(mobile):'))
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -110,7 +110,7 @@ jobs:
           echo "build_version=${next_build}" >> "$GITHUB_OUTPUT"
           echo "Desktop build version: ${next_build}"
 
-      - name: Trigger Desktop Build
+      - name: Trigger Desktop Tag Version Build
         if: needs.create_tag.outputs.platform == 'desktop' && needs.create_tag.outputs.ref_name == 'main'
         uses: actions/github-script@v8
         with:
@@ -123,11 +123,29 @@ jobs:
               ref: 'main',
               inputs: {
                 tag_version: 'true',
+                store: 'false'
+              }
+            });
+            console.log('Desktop Tag Version build triggered successfully');
+
+      - name: Trigger Desktop Store Build
+        if: needs.create_tag.outputs.platform == 'desktop' && needs.create_tag.outputs.ref_name == 'main'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const response = await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-desktop.yml',
+              ref: 'main',
+              inputs: {
+                tag_version: 'false',
                 store: 'true',
                 build_version: '${{ steps.desktop_build_version.outputs.build_version }}'
               }
             });
-            console.log('Desktop build triggered successfully');
+            console.log('Desktop store build triggered successfully');
 
       - name: Trigger Mobile Preview Release Build
         if: needs.create_tag.outputs.platform == 'mobile' && needs.create_tag.outputs.ref_name == 'mobile-main'


### PR DESCRIPTION
### Description

This PR fixes desktop and mobile release workflow gating by matching release commits inside merge commit messages (`contains` instead of `startsWith`).
It updates desktop release orchestration to trigger two workflow_dispatch runs (Tag Version and Store) and adjusts desktop concurrency grouping so both runs can execute in parallel.
It also updates desktop/mobile release skills to commit changelog changes before running `pnpm bump` and to verify a clean working tree.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

Please focus review on workflow trigger conditions and desktop concurrency grouping behavior.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
