### PR TITLE
fix(ssr): disable tsdown inlineOnly check for worker build

### DIFF
--- a/apps/ssr/tsdown.worker.config.ts
+++ b/apps/ssr/tsdown.worker.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   format: ["esm"],
   external: ["node:*", /\.wasm$/],
   noExternal: ["**"],
+  inlineOnly: false,
   treeshake: true,
   splitting: false,
 


### PR DESCRIPTION
## Summary
- Fix Cloudflare Workers deploy CI failing with exit code 1
- The worker build intentionally bundles all dependencies (`noExternal: ["**"]`) for Cloudflare Workers, but tsdown v0.20.3 treats bundled dependencies as an error by default
- Set `inlineOnly: false` in `tsdown.worker.config.ts` to suppress this check

## Test plan
- [ ] Verify `deploy-cloudflare` workflow passes on this branch
- [ ] Verify worker deployment still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)