### PR TITLE
fix(ssr): remove upstream env switching

### DIFF
--- a/apps/ssr/client/lib/api-fetch.ts
+++ b/apps/ssr/client/lib/api-fetch.ts
@@ -9,7 +9,7 @@ import PKG from "../../../desktop/package.json"
 export const followClient = new FollowClient({
   credentials: "include",
   timeout: 30000,
-  baseURL: env.VITE_EXTERNAL_API_URL || env.VITE_API_URL,
+  baseURL: env.VITE_API_URL,
   fetch: async (input: any, options = {}) =>
     fetch(input.toString(), {
       ...options,

--- a/apps/ssr/index.ts
+++ b/apps/ssr/index.ts
@@ -5,7 +5,6 @@ import os from "node:os"
 
 import middie from "@fastify/middie"
 import { fastifyRequestContext } from "@fastify/request-context"
-import { env } from "@follow/shared/env.ssr"
 import type { FastifyRequest } from "fastify"
 import Fastify from "fastify"
 import { nanoid } from "nanoid"
@@ -20,9 +19,6 @@ const isVercel = process.env.VERCEL === "1"
 declare module "@fastify/request-context" {
   interface RequestContextData {
     req: FastifyRequest
-
-    upstreamEnv: "prod" | "dev"
-    upstreamOrigin: string
   }
 }
 
@@ -60,13 +56,6 @@ export const createApp = async () => {
     const forwardedHost = req.headers["x-forwarded-host"]
     const finalHost = forwardedHost || host
 
-    const upstreamEnv = finalHost?.includes("dev") ? "dev" : "prod"
-    if (!__DEV__) req.requestContext.set("upstreamEnv", upstreamEnv)
-    if (upstreamEnv === "prod") {
-      req.requestContext.set("upstreamOrigin", env.VITE_WEB_PROD_URL || env.VITE_WEB_URL)
-    } else {
-      req.requestContext.set("upstreamOrigin", env.VITE_WEB_DEV_URL || env.VITE_WEB_URL)
-    }
     reply.header("x-handled-host", finalHost)
     done()
   })

--- a/apps/ssr/src/lib/api-client.ts
+++ b/apps/ssr/src/lib/api-client.ts
@@ -11,18 +11,10 @@ import PKG from "../../../desktop/package.json"
 const getBaseURL = () => {
   const req = requestContext.get("req")!
   const { host } = req.headers
-  let baseURL = env.VITE_EXTERNAL_API_URL || env.VITE_API_URL
+  let baseURL = env.VITE_API_URL
 
-  if (env.VITE_EXTERNAL_API_URL?.startsWith("/")) {
-    baseURL = `http://${host}${env.VITE_EXTERNAL_API_URL}`
-  }
-
-  const upstreamEnv = req.requestContext.get("upstreamEnv")
-  if (upstreamEnv === "dev" && env.VITE_EXTERNAL_DEV_API_URL) {
-    baseURL = env.VITE_EXTERNAL_DEV_API_URL
-  }
-  if (upstreamEnv === "prod" && env.VITE_EXTERNAL_PROD_API_URL) {
-    baseURL = env.VITE_EXTERNAL_PROD_API_URL
+  if (env.VITE_API_URL.startsWith("/")) {
+    baseURL = `http://${host}${env.VITE_API_URL}`
   }
   return baseURL
 }

--- a/apps/ssr/src/meta-handler.ts
+++ b/apps/ssr/src/meta-handler.ts
@@ -1,3 +1,4 @@
+import { env } from "@follow/shared/env.ssr"
 import type { FollowClient } from "@follow-app/client-sdk"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { match } from "path-to-regexp"
@@ -41,12 +42,12 @@ export async function injectMetaHandler(
   res: FastifyReply,
 ): Promise<MetaTag[]> {
   const apiClient = createFollowClient()
-  const upstreamOrigin = req.requestContext.get("upstreamOrigin")
+  const webOrigin = env.VITE_WEB_URL
   const url = req.originalUrl
 
   for (const [pattern, handler] of Object.entries(importer)) {
     const matchFn = match(pattern, { decode: decodeURIComponent })
-    const parsedUrl = new URL(url, upstreamOrigin)
+    const parsedUrl = new URL(url, webOrigin)
     const result = matchFn(parsedUrl.pathname)
 
     if (result) {
@@ -56,7 +57,7 @@ export async function injectMetaHandler(
         url: parsedUrl,
         req,
         apiClient,
-        origin: upstreamOrigin || "",
+        origin: webOrigin,
         setStatus(status) {
           res.status(status)
         },

--- a/apps/ssr/src/router/global.ts
+++ b/apps/ssr/src/router/global.ts
@@ -42,40 +42,17 @@ const prodHandler = (app: FastifyInstance) => {
     const { document } = parseHTML(template)
     await safeInjectMetaToTemplate(document, req, reply)
 
-    const isInVercelReverseProxy = req.headers["x-middleware-subrequest"]
-
-    const upstreamEnv = req.requestContext.get("upstreamEnv")
-    if (isInVercelReverseProxy || upstreamEnv === "prod") {
-      const upstreamEnv = req.requestContext.get("upstreamEnv")
-
-      if (upstreamEnv) {
-        document.head.prepend(document.createComment(`upstreamEnv: ${upstreamEnv}`))
-
-        // override client side api url
-
-        const upstreamOrigin = req.requestContext.get("upstreamOrigin")
-
-        const injectScript = (apiUrl: string) => {
-          const template = `function injectEnv(env2) {
+    const scriptContent = `function injectEnv(env2) {
     for (const key in env2) {
       if (env2[key] === void 0) continue;
       globalThis["__followEnv"] ??= {};
       globalThis["__followEnv"][key] = env2[key];
     }
   }
-injectEnv({"VITE_API_URL":"${apiUrl}","VITE_EXTERNAL_API_URL":"${apiUrl}","VITE_WEB_URL":"${upstreamOrigin}"})`
-          const $script = document.createElement("script")
-          $script.innerHTML = template
-          document.head.prepend($script)
-        }
-        if (upstreamEnv === "dev" && env.VITE_EXTERNAL_DEV_API_URL) {
-          injectScript(env.VITE_EXTERNAL_DEV_API_URL)
-        }
-        if (upstreamEnv === "prod" && env.VITE_EXTERNAL_PROD_API_URL) {
-          injectScript(env.VITE_EXTERNAL_PROD_API_URL)
-        }
-      }
-    }
+injectEnv({"VITE_API_URL":"${env.VITE_API_URL}","VITE_WEB_URL":"${env.VITE_WEB_URL}"})`
+    const $script = document.createElement("script")
+    $script.innerHTML = scriptContent
+    document.head.prepend($script)
 
     reply.type("text/html")
     reply.send(

--- a/apps/ssr/worker-app.ts
+++ b/apps/ssr/worker-app.ts
@@ -1,5 +1,4 @@
 import { fastifyRequestContext } from "@fastify/request-context"
-import { env } from "@follow/shared/env.ssr"
 import type { FastifyRequest } from "fastify"
 import Fastify from "fastify"
 import { nanoid } from "nanoid"
@@ -12,8 +11,6 @@ import { ogRoute } from "./src/router/og"
 declare module "@fastify/request-context" {
   interface RequestContextData {
     req: FastifyRequest
-    upstreamEnv: "prod" | "dev"
-    upstreamOrigin: string
   }
 }
 
@@ -52,13 +49,6 @@ export const createApp = () => {
       const forwardedHost = req.headers["x-forwarded-host"]
       const finalHost = forwardedHost || host
 
-      const upstreamEnv = finalHost?.includes("dev") ? "dev" : "prod"
-      req.requestContext.set("upstreamEnv", upstreamEnv)
-      if (upstreamEnv === "prod") {
-        req.requestContext.set("upstreamOrigin", env.VITE_WEB_PROD_URL || env.VITE_WEB_URL)
-      } else {
-        req.requestContext.set("upstreamOrigin", env.VITE_WEB_DEV_URL || env.VITE_WEB_URL)
-      }
       reply.header("x-handled-host", finalHost)
       done()
     })

--- a/apps/ssr/worker-entry.ts
+++ b/apps/ssr/worker-entry.ts
@@ -38,9 +38,6 @@ interface Env {
   ASSETS: Fetcher
   VITE_API_URL: string
   VITE_WEB_URL: string
-  VITE_EXTERNAL_DEV_API_URL: string
-  VITE_EXTERNAL_PROD_API_URL: string
-  VITE_WEB_DEV_URL: string
   VITE_SENTRY_DSN: string
 }
 
@@ -75,12 +72,9 @@ app.use("*", async (c, next) => {
   }
 
   return runWithRequestContext(async () => {
-    // Determine upstream env from host
     const host = c.req.header("host") || ""
     const forwardedHost = c.req.header("x-forwarded-host")
     const finalHost = forwardedHost || host
-    const upstreamEnv =
-      finalHost === "dev.folo.is" || finalHost?.includes("folo-ssr-dev") ? "dev" : "prod"
 
     // Create a req-like proxy for compatibility with existing modules
     const headers: Record<string, string> = {}
@@ -95,12 +89,6 @@ app.use("*", async (c, next) => {
 
     // Set request context values
     requestContext.set("req", reqProxy)
-    requestContext.set("upstreamEnv", upstreamEnv)
-    if (upstreamEnv === "prod") {
-      requestContext.set("upstreamOrigin", env.VITE_WEB_PROD_URL || env.VITE_WEB_URL)
-    } else {
-      requestContext.set("upstreamOrigin", env.VITE_WEB_DEV_URL || env.VITE_WEB_URL)
-    }
 
     await next()
 
@@ -231,32 +219,17 @@ export default app
 
 // Helper: inject env vars into HTML document
 function injectEnvToDocument(document: any) {
-  const upstreamEnv = requestContext.get("upstreamEnv") as string
-  const upstreamOrigin = requestContext.get("upstreamOrigin") as string
-
-  if (upstreamEnv) {
-    document.head.prepend(document.createComment(`upstreamEnv: ${upstreamEnv}`))
-
-    const injectScript = (apiUrl: string) => {
-      const scriptContent = `function injectEnv(env2) {
+  const scriptContent = `function injectEnv(env2) {
     for (const key in env2) {
       if (env2[key] === void 0) continue;
       globalThis["__followEnv"] ??= {};
       globalThis["__followEnv"][key] = env2[key];
     }
   }
-injectEnv({"VITE_API_URL":"${apiUrl}","VITE_EXTERNAL_API_URL":"${apiUrl}","VITE_WEB_URL":"${upstreamOrigin}"})`
-      const $script = document.createElement("script")
-      $script.innerHTML = scriptContent
-      document.head.prepend($script)
-    }
-    if (upstreamEnv === "dev" && env.VITE_EXTERNAL_DEV_API_URL) {
-      injectScript(env.VITE_EXTERNAL_DEV_API_URL)
-    }
-    if (upstreamEnv === "prod" && env.VITE_EXTERNAL_PROD_API_URL) {
-      injectScript(env.VITE_EXTERNAL_PROD_API_URL)
-    }
-  }
+injectEnv({"VITE_API_URL":"${env.VITE_API_URL}","VITE_WEB_URL":"${env.VITE_WEB_URL}"})`
+  const $script = document.createElement("script")
+  $script.innerHTML = scriptContent
+  document.head.prepend($script)
 }
 
 // Helper: inject meta tags into HTML document

--- a/apps/ssr/wrangler.jsonc
+++ b/apps/ssr/wrangler.jsonc
@@ -40,9 +40,6 @@
   "vars": {
     "VITE_API_URL": "https://api.folo.is",
     "VITE_WEB_URL": "https://app.folo.is",
-    "VITE_EXTERNAL_DEV_API_URL": "https://api.dev.folo.is",
-    "VITE_EXTERNAL_PROD_API_URL": "https://api.folo.is",
-    "VITE_WEB_DEV_URL": "https://dev.folo.is",
     "VITE_SENTRY_DSN": "https://e5bccf7428aa4e881ed5cb713fdff181@o4507542488023040.ingest.us.sentry.io/4507570439979008",
   },
   "env": {
@@ -64,9 +61,6 @@
       "vars": {
         "VITE_API_URL": "https://api.dev.folo.is",
         "VITE_WEB_URL": "https://dev.folo.is",
-        "VITE_EXTERNAL_DEV_API_URL": "https://api.dev.folo.is",
-        "VITE_EXTERNAL_PROD_API_URL": "https://api.folo.is",
-        "VITE_WEB_DEV_URL": "https://dev.folo.is",
         "VITE_SENTRY_DSN": "https://e5bccf7428aa4e881ed5cb713fdff181@o4507542488023040.ingest.us.sentry.io/4507570439979008",
       },
     },

--- a/packages/internal/shared/src/env.ssr.ts
+++ b/packages/internal/shared/src/env.ssr.ts
@@ -22,13 +22,6 @@ export const env = createEnv({
     VITE_POSTHOG_KEY: z.string().optional().default(DEFAULT_VALUES.PROD.POSTHOG_KEY),
     VITE_POSTHOG_HOST: z.string().url().optional().default(DEFAULT_VALUES.PROD.POSTHOG_HOST),
 
-    // For external, use api_url if you don't want to fill it in.
-    VITE_EXTERNAL_PROD_API_URL: z.string().optional(),
-    VITE_EXTERNAL_DEV_API_URL: z.string().optional(),
-    VITE_EXTERNAL_API_URL: z.string().optional(),
-    VITE_WEB_PROD_URL: z.string().optional(),
-    VITE_WEB_DEV_URL: z.string().optional(),
-
     VITE_RECAPTCHA_V3_SITE_KEY: z.string().default(DEFAULT_VALUES.PROD.RECAPTCHA_V3_SITE_KEY),
   },
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR removes host-based `upstreamEnv`/`upstreamOrigin` branching from SSR and standardizes configuration to only use `VITE_API_URL` and `VITE_WEB_URL`.
It updates server/client API base URL resolution, HTML env injection, and meta URL origin handling to use the same env source consistently.
It also removes obsolete external/dev/prod-specific SSR env keys from `env.ssr` and `wrangler.jsonc` while keeping dev/prod values separated through Wrangler `vars` and `env.dev.vars`.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

`pnpm --filter @follow/ssr typecheck` passed.

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
