### PR TITLE
fix(desktop): switch AI spline asset domain

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/ai-chat/components/3d-models/AISplineLoader.tsx
+++ b/apps/desktop/layer/renderer/src/modules/ai-chat/components/3d-models/AISplineLoader.tsx
@@ -2,7 +2,7 @@ import { clamp, cn } from "@follow/utils"
 import Spline from "@splinetool/react-spline"
 import { useCallback, useRef } from "react"
 
-const resolvedAIIconUrl = "https://cdn.follow.is/ai2.splinecode"
+const resolvedAIIconUrl = "https://assets.folo.is/ai2.splinecode"
 
 export const AISplineLoader = ({ className }: { className?: string }) => {
   const containerRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
### Description
Replace the AI spline model URL in `AISplineLoader` from `cdn.follow.is` to `assets.folo.is` so the loader fetches assets from the new domain.

### PR Type
- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)
N/A

### Demo Video (if new feature)
N/A

### Linked Issues
N/A

### Additional context
This PR only updates one asset host constant in desktop renderer.

### Changelog
- [ ] I have updated the changelog/next.md with my changes.
