### PR TITLE
feat(mobile): add French i18n support

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -57,7 +57,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         LSApplicationQueriesSchemes: ["bilibili", "youtube"],
         CFBundleAllowMixedLocalizations: true,
         // apps/mobile/src/@types/constants.ts currentSupportedLanguages
-        CFBundleLocalizations: ["en", "ja", "zh-CN", "zh-TW"],
+        CFBundleLocalizations: ["en", "ja", "zh-CN", "zh-TW", "fr-FR"],
         CFBundleDevelopmentRegion: "en",
       },
       googleServicesFile: "./build/GoogleService-Info.plist",

--- a/apps/mobile/ios/Folo/Info.plist
+++ b/apps/mobile/ios/Folo/Info.plist
@@ -26,6 +26,7 @@
 		<string>ja</string>
 		<string>zh-CN</string>
 		<string>zh-TW</string>
+		<string>fr-FR</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>

--- a/apps/mobile/src/@types/constants.ts
+++ b/apps/mobile/src/@types/constants.ts
@@ -1,4 +1,4 @@
-const langs = ["en", "ja", "zh-CN", "zh-TW"] as const
+const langs = ["en", "ja", "zh-CN", "zh-TW", "fr-FR"] as const
 export const currentSupportedLanguages = langs as readonly string[]
 export type MobileSupportedLanguages = (typeof langs)[number]
 
@@ -10,4 +10,5 @@ export const dayjsLocaleImportMap = {
   ["zh-CN"]: ["zh-cn", () => import("dayjs/locale/zh-cn")],
   ["ja"]: ["ja", () => import("dayjs/locale/ja")],
   ["zh-TW"]: ["zh-tw", () => import("dayjs/locale/zh-tw")],
+  ["fr-FR"]: ["fr", () => import("dayjs/locale/fr")],
 } as const

--- a/apps/mobile/src/@types/default-resource.ts
+++ b/apps/mobile/src/@types/default-resource.ts
@@ -1,20 +1,25 @@
 import common_en from "@locales/common/en.json"
+import common_frFR from "@locales/common/fr-FR.json"
 import common_ja from "@locales/common/ja.json"
 import common_zhCN from "@locales/common/zh-CN.json"
 import common_zhTW from "@locales/common/zh-TW.json"
 import errors_en from "@locales/errors/en.json"
+import errors_frFR from "@locales/errors/fr-FR.json"
 import errors_ja from "@locales/errors/ja.json"
 import errors_zhCN from "@locales/errors/zh-CN.json"
 import errors_zhTW from "@locales/errors/zh-TW.json"
 import lang_en from "@locales/lang/en.json"
+import lang_frFR from "@locales/lang/fr-FR.json"
 import lang_ja from "@locales/lang/ja.json"
 import lang_zhCN from "@locales/lang/zh-CN.json"
 import lang_zhTW from "@locales/lang/zh-TW.json"
 import en from "@locales/mobile/default/en.json"
+import frFR from "@locales/mobile/default/fr-FR.json"
 import ja from "@locales/mobile/default/ja.json"
 import zhCN from "@locales/mobile/default/zh-CN.json"
 import zhTW from "@locales/mobile/default/zh-TW.json"
 import settings_en from "@locales/settings/en.json"
+import settings_frFR from "@locales/settings/fr-FR.json"
 import settings_ja from "@locales/settings/ja.json"
 import settings_zhCN from "@locales/settings/zh-CN.json"
 import settings_zhTW from "@locales/settings/zh-TW.json"
@@ -23,6 +28,13 @@ import type { MobileSupportedLanguages, ns } from "./constants"
 
 // @keep-sorted
 export const defaultResources = {
+  "fr-FR": {
+    common: common_frFR,
+    default: frFR,
+    errors: errors_frFR,
+    lang: lang_frFR,
+    settings: settings_frFR,
+  },
   // @keep-sorted
   "zh-CN": {
     common: common_zhCN,


### PR DESCRIPTION
### Description

This PR enables French (`fr-FR`) in the mobile app i18n pipeline.
It adds `fr-FR` to mobile supported languages, dayjs locale mapping, and mobile default resource registration.
It also updates iOS localization declarations in Expo config and Info.plist so the locale is exposed at platform level.

### PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

No behavior changes outside mobile locale availability.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
