### PR TITLE
chore(env): update default reCAPTCHA v3 site key

### DIFF
--- a/packages/internal/shared/src/env.common.ts
+++ b/packages/internal/shared/src/env.common.ts
@@ -16,7 +16,7 @@ export const DEFAULT_VALUES = {
     FIREBASE_CONFIG: FIREBASE_CONFIG_DEFAULT,
     OPENPANEL_CLIENT_ID: "4382168f-b8d2-40c1-9a26-133a312d072b",
     OPENPANEL_API_URL: "https://openpanel.follow.is/api",
-    RECAPTCHA_V3_SITE_KEY: "6LeNhgwsAAAAAHO1dhunH0a-FI1YvOc9Ny98Oast",
+    RECAPTCHA_V3_SITE_KEY: "6LeGa3csAAAAALi_WqhlWoaGaqd_kke4HRGvNE0C",
 
     POSTHOG_KEY: "phc_EZGEvBt830JgBHTiwpHqJAEbWnbv63m5UpreojwEWNL",
     POSTHOG_HOST: "https://us.posthog.com",


### PR DESCRIPTION
### Description

Update the default `RECAPTCHA_V3_SITE_KEY` in shared env defaults so desktop and SSR clients use the new key when no runtime override is provided.

### PR Type

- [ ] Feature
- [ ] Bugfix
- [ ] Hotfix
- [x] Other (please describe): Configuration update

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

This change only updates the fallback key in `packages/internal/shared/src/env.common.ts`.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
