### PR TITLE
fix(mobile): align translation gating with real roles

### DIFF
--- a/apps/mobile/src/modules/entry-list/EntryListContentArticle.tsx
+++ b/apps/mobile/src/modules/entry-list/EntryListContentArticle.tsx
@@ -1,5 +1,5 @@
 import type { FeedViewType } from "@follow/constants"
-import { isFreeRole } from "@follow/constants"
+import { UserRole } from "@follow/constants"
 import { usePrefetchEntryTranslation } from "@follow/store/translation/hooks"
 import { useUserRole } from "@follow/store/user/hooks"
 import type { FlashListRef, ListRenderItemInfo } from "@shopify/flash-list"
@@ -71,7 +71,9 @@ export const EntryListContentArticle = ({
   const translationMode = useGeneralSettingKey("translationMode")
   const actionLanguage = useActionLanguage()
   const userRole = useUserRole()
-  const translationPrefetchEnabled = translation && !isFreeRole(userRole)
+  const translationPrefetchEnabled =
+    translation && (userRole == null || (userRole !== UserRole.Free && userRole !== UserRole.Trial))
+
   usePrefetchEntryTranslation({
     entryIds: active ? viewableItems.map((item) => item.key) : [],
     language: actionLanguage,

--- a/apps/mobile/src/modules/entry-list/EntryListContentPicture.tsx
+++ b/apps/mobile/src/modules/entry-list/EntryListContentPicture.tsx
@@ -1,5 +1,5 @@
 import type { FeedViewType } from "@follow/constants"
-import { isFreeRole } from "@follow/constants"
+import { UserRole } from "@follow/constants"
 import { useTypeScriptHappyCallback } from "@follow/hooks"
 import { usePrefetchEntryTranslation } from "@follow/store/translation/hooks"
 import { useUserRole } from "@follow/store/user/hooks"
@@ -51,7 +51,8 @@ export const EntryListContentPicture = ({
   const translationMode = useGeneralSettingKey("translationMode")
   const actionLanguage = useActionLanguage()
   const userRole = useUserRole()
-  const translationPrefetchEnabled = translation && !isFreeRole(userRole)
+  const translationPrefetchEnabled =
+    translation && (userRole == null || (userRole !== UserRole.Free && userRole !== UserRole.Trial))
   usePrefetchEntryTranslation({
     entryIds: active ? viewableItems.map((item) => item.key) : [],
     language: actionLanguage,

--- a/apps/mobile/src/modules/entry-list/EntryListContentSocial.tsx
+++ b/apps/mobile/src/modules/entry-list/EntryListContentSocial.tsx
@@ -1,5 +1,5 @@
 import type { FeedViewType } from "@follow/constants"
-import { isFreeRole } from "@follow/constants"
+import { UserRole } from "@follow/constants"
 import { usePrefetchEntryTranslation } from "@follow/store/translation/hooks"
 import { useUserRole } from "@follow/store/user/hooks"
 import type { FlashListRef, ListRenderItemInfo } from "@shopify/flash-list"
@@ -54,7 +54,8 @@ export const EntryListContentSocial = ({
   const translationMode = useGeneralSettingKey("translationMode")
   const actionLanguage = useActionLanguage()
   const userRole = useUserRole()
-  const translationPrefetchEnabled = translation && !isFreeRole(userRole)
+  const translationPrefetchEnabled =
+    translation && (userRole == null || (userRole !== UserRole.Free && userRole !== UserRole.Trial))
   usePrefetchEntryTranslation({
     entryIds: active ? viewableItems.map((item) => item.key) : [],
     language: actionLanguage,

--- a/apps/mobile/src/modules/entry-list/EntryListContentVideo.tsx
+++ b/apps/mobile/src/modules/entry-list/EntryListContentVideo.tsx
@@ -1,5 +1,5 @@
 import type { FeedViewType } from "@follow/constants"
-import { isFreeRole } from "@follow/constants"
+import { UserRole } from "@follow/constants"
 import { useTypeScriptHappyCallback } from "@follow/hooks"
 import { usePrefetchEntryTranslation } from "@follow/store/translation/hooks"
 import { useUserRole } from "@follow/store/user/hooks"
@@ -44,7 +44,8 @@ export const EntryListContentVideo = ({
   const translationMode = useGeneralSettingKey("translationMode")
   const actionLanguage = useActionLanguage()
   const userRole = useUserRole()
-  const translationPrefetchEnabled = translation && !isFreeRole(userRole)
+  const translationPrefetchEnabled =
+    translation && (userRole == null || (userRole !== UserRole.Free && userRole !== UserRole.Trial))
   usePrefetchEntryTranslation({
     entryIds: active ? viewableItems.map((item) => item.key) : [],
     language: actionLanguage,

--- a/apps/mobile/src/screens/(stack)/entries/[entryId]/EntryDetailScreen.tsx
+++ b/apps/mobile/src/screens/(stack)/entries/[entryId]/EntryDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { FeedViewType, isFreeRole } from "@follow/constants"
+import { FeedViewType, UserRole } from "@follow/constants"
 import { useEntry, useEntryReadHistory, usePrefetchEntryDetail } from "@follow/store/entry/hooks"
 import { entrySyncServices } from "@follow/store/entry/store"
 import { useFeedById } from "@follow/store/feed/hooks"
@@ -147,7 +147,10 @@ const EntryContentWebViewWithContext = ({ entryId }: { entryId: string }) => {
   const showTranslationOnce = useAtomValue(showAITranslationAtom)
   const actionLanguage = useActionLanguage()
   const userRole = useUserRole()
-  const translationPrefetchEnabled = translationSetting && !isFreeRole(userRole)
+  const showTranslation = translationSetting || showTranslationOnce
+  const translationPrefetchEnabled =
+    showTranslation &&
+    (userRole == null || (userRole !== UserRole.Free && userRole !== UserRole.Trial))
   const entry = useEntry(entryId, (state) => ({
     content: state.content,
     readabilityContent: state.readabilityContent,
@@ -187,7 +190,7 @@ const EntryContentWebViewWithContext = ({ entryId }: { entryId: string }) => {
     <EntryContentWebView
       entryId={entryId}
       showReadability={showReadabilityOnce}
-      showTranslation={translationSetting || showTranslationOnce}
+      showTranslation={showTranslation}
     />
   )
 }

--- a/packages/internal/constants/src/enums.ts
+++ b/packages/internal/constants/src/enums.ts
@@ -6,7 +6,6 @@ export enum Routes {
 
 export enum UserRole {
   Admin = "admin",
-  PreProTrial = "pre_pro_trial",
   Free = "free",
   /**
    * @deprecated
@@ -21,7 +20,6 @@ export enum UserRole {
 
 export const UserRoleName: Record<UserRole, string> = {
   [UserRole.Admin]: "Admin",
-  [UserRole.PreProTrial]: "Pro Preview Trial",
   [UserRole.Free]: "Free",
   /**
    * @deprecated
@@ -38,13 +36,10 @@ export const UserRolePriority: Record<UserRole, number> = {
   [UserRole.Pro]: 3,
   [UserRole.Plus]: 2,
   [UserRole.Basic]: 1,
-  [UserRole.PreProTrial]: 0,
   [UserRole.Free]: 0,
   [UserRole.Trial]: 0,
 } as const
 
 export const isFreeRole = (role?: UserRole | null) => {
-  return role
-    ? role === UserRole.Free || role === UserRole.Trial || role === UserRole.PreProTrial
-    : true
+  return role ? role === UserRole.Free || role === UserRole.Trial : true
 }

--- a/packages/internal/store/src/lib/stream.ts
+++ b/packages/internal/store/src/lib/stream.ts
@@ -1,19 +1,12 @@
 type LineHandler<T> = (data: T) => void | Promise<void>
 
-/**
- * Read a Response body as a newline-delimited JSON stream.
- * Each complete line will be parsed and passed to onLine.
- */
-export async function readNdjsonStream<T = unknown>(response: Response, onLine: LineHandler<T>) {
-  const reader = response.body?.getReader()
-  if (!reader) return
+const processNdjsonText = async <T = unknown>(text: string, onLine: LineHandler<T>) => {
+  const lines = text.split("\n")
 
-  const decoder = new TextDecoder()
-  let buffer = ""
-
-  const processLine = async (line: string) => {
+  for (const line of lines) {
     const trimmed = line.trim()
-    if (!trimmed) return
+    if (!trimmed) continue
+
     try {
       const json = JSON.parse(trimmed) as T
       await onLine(json)
@@ -21,6 +14,21 @@ export async function readNdjsonStream<T = unknown>(response: Response, onLine: 
       console.error("Failed to parse NDJSON line:", error)
     }
   }
+}
+
+/**
+ * Read a Response body as a newline-delimited JSON stream.
+ * Each complete line will be parsed and passed to onLine.
+ */
+export async function readNdjsonStream<T = unknown>(response: Response, onLine: LineHandler<T>) {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    await processNdjsonText<T>(await response.text(), onLine)
+    return
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ""
 
   try {
     while (true) {
@@ -29,13 +37,13 @@ export async function readNdjsonStream<T = unknown>(response: Response, onLine: 
       buffer += decoder.decode(value, { stream: true })
       const lines = buffer.split("\n")
       for (let i = 0; i < lines.length - 1; i++) {
-        await processLine(lines[i]!)
+        await processNdjsonText<T>(lines[i]!, onLine)
       }
       buffer = lines.at(-1) || ""
     }
 
     if (buffer.trim()) {
-      await processLine(buffer)
+      await processNdjsonText<T>(buffer, onLine)
     }
   } finally {
     reader.releaseLock()

--- a/packages/internal/store/src/modules/translation/hooks.ts
+++ b/packages/internal/store/src/modules/translation/hooks.ts
@@ -47,6 +47,7 @@ export const usePrefetchEntryTranslation = ({
   }, [queryClient, translationMode])
 
   const isLoggedIn = useIsLoggedIn()
+
   return useQueries({
     queries: isLoggedIn
       ? entryList.map((entry) => {


### PR DESCRIPTION
## Summary\n- remove the deprecated \ role from shared frontend enums\n- align mobile translation gating with the real paid role logic used by desktop\n- keep the mobile translation rendering/prefetch fix and NDJSON fallback for Expo fetch\n\n## Verification\n- pnpm --filter @follow/mobile typecheck\n- pnpm exec eslint "apps/mobile/src/modules/entry-list/EntryListContentArticle.tsx" "apps/mobile/src/modules/entry-list/EntryListContentPicture.tsx" "apps/mobile/src/modules/entry-list/EntryListContentSocial.tsx" "apps/mobile/src/modules/entry-list/EntryListContentVideo.tsx" "apps/mobile/src/screens/(stack)/entries/[entryId]/EntryDetailScreen.tsx" "packages/internal/constants/src/enums.ts" "packages/internal/store/src/lib/stream.ts" "packages/internal/store/src/modules/translation/hooks.ts" "packages/internal/store/src/modules/translation/store.ts"\n- verified on iOS simulator against local follow-server