### PR TITLE
fix(mobile): polish settings and discover ui

### DIFF
--- a/apps/mobile/src/components/ui/form/Select.android.tsx
+++ b/apps/mobile/src/components/ui/form/Select.android.tsx
@@ -113,7 +113,7 @@ export function Select<T>({
     >
       <Text
         className={cn("flex-1 text-right font-semibold", disabled ? "text-gray" : "text-accent")}
-        ellipsizeMode="middle"
+        ellipsizeMode="tail"
         numberOfLines={1}
       >
         {displayValue || selectedOption?.label || "Select"}

--- a/apps/mobile/src/components/ui/form/Select.tsx
+++ b/apps/mobile/src/components/ui/form/Select.tsx
@@ -58,7 +58,7 @@ export function Select<T>({
         >
           <Text
             className={cn("flex-1 text-right font-semibold text-accent", disabled && "text-gray")}
-            ellipsizeMode="middle"
+            ellipsizeMode="tail"
             numberOfLines={1}
           >
             {displayValue || valueToLabelMap.get(currentValue) || "Select"}

--- a/apps/mobile/src/components/ui/switch/Switch.tsx
+++ b/apps/mobile/src/components/ui/switch/Switch.tsx
@@ -1,13 +1,6 @@
-import { useEffect, useImperativeHandle } from "react"
+import { useImperativeHandle } from "react"
 import type { SwitchChangeEvent } from "react-native"
-import { Pressable, StyleSheet } from "react-native"
-import Animated, {
-  interpolate,
-  interpolateColor,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from "react-native-reanimated"
+import { Platform, StyleSheet, Switch as NativeSwitch } from "react-native"
 
 import { accentColor, useColor } from "@/src/theme/colors"
 
@@ -26,6 +19,10 @@ export interface SwitchProps {
   value?: boolean | undefined
 
   size?: "sm" | "default"
+
+  disabled?: boolean | undefined
+
+  testID?: string | undefined
 }
 
 export type SwitchRef = {
@@ -37,100 +34,39 @@ export const Switch = ({
   onValueChange,
   onChange,
   size = "default",
+  disabled = false,
+  testID,
 }: SwitchProps & { ref?: React.Ref<SwitchRef | null> }) => {
-  const gray3 = useColor("gray3")
-  const animatedValue = useSharedValue(value ? 1 : 0)
+  const gray4 = useColor("gray4")
 
-  const dimensions =
-    size === "sm"
-      ? { width: 40, height: 24, thumbSize: 20 }
-      : { width: 48, height: 28, thumbSize: 24 }
-
-  useEffect(() => {
-    animatedValue.value = withSpring(value ? 1 : 0, {
-      damping: 15,
-      stiffness: 200,
-    })
-  }, [animatedValue, value])
-
-  useImperativeHandle(ref, () => ({
-    value: value || false,
-  }))
-
-  const handlePress = () => {
-    const newValue = !value
-    onValueChange?.(newValue)
-    onChange?.({
-      nativeEvent: { value: newValue },
-    } as SwitchChangeEvent)
-  }
-
-  const trackAnimatedStyle = useAnimatedStyle(() => {
-    const backgroundColor = interpolateColor(animatedValue.value, [0, 1], [gray3, accentColor])
-
-    return {
-      backgroundColor,
-    }
-  })
-
-  const thumbAnimatedStyle = useAnimatedStyle(() => {
-    const translateX = interpolate(
-      animatedValue.value,
-      [0, 1],
-      [2, dimensions.width - dimensions.thumbSize - 2],
-    )
-
-    return {
-      transform: [{ translateX }],
-    }
-  })
+  useImperativeHandle(
+    ref,
+    () => ({
+      value,
+    }),
+    [value],
+  )
 
   return (
-    <Pressable onPress={handlePress} className="opacity-100" style={styles.container}>
-      <Animated.View
-        style={[
-          styles.track,
-          { width: dimensions.width, height: dimensions.height },
-          trackAnimatedStyle,
-        ]}
-      >
-        <Animated.View
-          style={[
-            styles.thumb,
-            {
-              width: dimensions.thumbSize,
-              height: dimensions.thumbSize,
-            },
-            thumbAnimatedStyle,
-          ]}
-        />
-      </Animated.View>
-    </Pressable>
+    <NativeSwitch
+      disabled={disabled}
+      ios_backgroundColor={gray4}
+      onChange={onChange ?? undefined}
+      onValueChange={onValueChange ?? undefined}
+      style={size === "sm" ? styles.small : styles.default}
+      testID={testID}
+      thumbColor={Platform.OS === "android" ? "#FFFFFF" : undefined}
+      trackColor={{ false: gray4, true: accentColor }}
+      value={value}
+    />
   )
 }
 
 const styles = StyleSheet.create({
-  container: {
-    justifyContent: "center",
-    alignItems: "center",
+  default: {
+    transform: [{ scaleX: 0.94 }, { scaleY: 0.94 }],
   },
-  track: {
-    borderRadius: 999,
-    justifyContent: "center",
-    position: "relative",
-  },
-  thumb: {
-    borderRadius: 999,
-    backgroundColor: "#FFFFFF",
-    position: "absolute",
-    top: 2,
-    shadowColor: "#000",
-    shadowOffset: {
-      width: 0,
-      height: 1,
-    },
-    shadowOpacity: 0.2,
-    shadowRadius: 2,
-    elevation: 3,
+  small: {
+    transform: [{ scaleX: 0.8 }, { scaleY: 0.8 }],
   },
 })

--- a/apps/mobile/src/modules/discover/Category.tsx
+++ b/apps/mobile/src/modules/discover/Category.tsx
@@ -1,9 +1,10 @@
 import type { RSSHubCategory } from "@follow/constants"
 import { CategoryMap, RSSHubCategories } from "@follow/constants"
+import { Image } from "expo-image"
 import { LinearGradient } from "expo-linear-gradient"
-import { memo } from "react"
+import { memo, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Pressable, StyleSheet, View } from "react-native"
+import { Platform, Pressable, StyleSheet, View } from "react-native"
 import { useColor } from "react-native-uikit-colors"
 
 import { Grid } from "@/src/components/ui/grid"
@@ -49,10 +50,46 @@ export const Category = () => {
     </>
   )
 }
+
+const emojiCdnBaseUrl = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72"
+
+const getEmojiImageUrl = (emoji: string) => {
+  const codePoints = Array.from(emoji)
+    .map((character) => character.codePointAt(0)?.toString(16))
+    .filter((value): value is string => Boolean(value) && value !== "fe0f")
+
+  return `${emojiCdnBaseUrl}/${codePoints.join("-")}.png`
+}
+
+const CategoryEmoji = ({ emoji }: { emoji: string }) => {
+  const [useTextFallback, setUseTextFallback] = useState(false)
+  const emojiImageUrl = useMemo(() => getEmojiImageUrl(emoji), [emoji])
+
+  return (
+    <View style={styles.emojiContainer}>
+      {useTextFallback ? (
+        <Text allowFontScaling={false} style={styles.emojiText}>
+          {emoji}
+        </Text>
+      ) : (
+        <Image
+          allowDownscaling
+          cachePolicy="memory-disk"
+          contentFit="contain"
+          onError={() => setUseTextFallback(true)}
+          source={emojiImageUrl}
+          style={styles.emojiImage}
+        />
+      )}
+    </View>
+  )
+}
+
 const CategoryItem = memo(({ category }: { category: RSSHubCategory }) => {
   const { t } = useTranslation("common")
   const name = t(`discover.category.${category}`)
   const navigation = useNavigation()
+  const { emoji } = CategoryMap[category]
   return (
     <Pressable
       className="overflow-hidden rounded-2xl"
@@ -81,7 +118,7 @@ const CategoryItem = memo(({ category }: { category: RSSHubCategory }) => {
         style={styles.cardItem}
       >
         <View className="flex-1">
-          <Text className="absolute right-2 top-2 text-4xl">{CategoryMap[category].emoji}</Text>
+          <CategoryEmoji emoji={emoji} />
           <Text className="absolute bottom-0 left-2 text-lg font-bold text-white">{name}</Text>
         </View>
       </LinearGradient>
@@ -91,5 +128,28 @@ const CategoryItem = memo(({ category }: { category: RSSHubCategory }) => {
 const styles = StyleSheet.create({
   cardItem: {
     aspectRatio: 16 / 9,
+  },
+  emojiContainer: {
+    position: "absolute",
+    right: 8,
+    top: 8,
+    width: 56,
+    height: 56,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emojiText: {
+    fontSize: 40,
+    lineHeight: 48,
+    textAlign: "center",
+    ...(Platform.OS === "android"
+      ? {
+          includeFontPadding: false,
+        }
+      : {}),
+  },
+  emojiImage: {
+    width: 40,
+    height: 40,
   },
 })

--- a/apps/mobile/src/modules/settings/routes/General.tsx
+++ b/apps/mobile/src/modules/settings/routes/General.tsx
@@ -2,7 +2,6 @@ import { ACTION_LANGUAGE_KEYS } from "@follow/shared"
 import i18next from "i18next"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { View } from "react-native"
 
 import type { MobileSupportedLanguages } from "@/src/@types/constants"
 import { currentSupportedLanguages } from "@/src/@types/constants"
@@ -21,6 +20,8 @@ import {
 import { Switch } from "@/src/components/ui/switch/Switch"
 import { updateDayjsLocale } from "@/src/lib/i18n"
 import type { NavigationControllerView } from "@/src/lib/navigation/types"
+
+const settingSelectWrapperClassName = "w-[200px]"
 
 export function LanguageSelect({ settingKey }: { settingKey: "language" | "actionLanguage" }) {
   const { t } = useTranslation("settings")
@@ -80,10 +81,9 @@ function LanguageSetting({ settingKey }: { settingKey: "language" | "actionLangu
           ? t("general.language.description")
           : t("general.action_language.description")
       }
+      rightClassName={settingSelectWrapperClassName}
     >
-      <View className="w-[100px]">
-        <LanguageSelect settingKey={settingKey} />
-      </View>
+      <LanguageSelect settingKey={settingKey} />
     </GroupedInsetListCell>
   )
 }
@@ -96,19 +96,18 @@ function TranslationModeSetting() {
     <GroupedInsetListCell
       label={t("general.translation_mode.label")}
       description={t("general.translation_mode.description")}
+      rightClassName={settingSelectWrapperClassName}
     >
-      <View className="w-[120px]">
-        <Select
-          value={translationMode}
-          onValueChange={(value) => {
-            setGeneralSetting("translationMode", value as "bilingual" | "translation-only")
-          }}
-          options={[
-            { label: t("general.translation_mode.bilingual"), value: "bilingual" },
-            { label: t("general.translation_mode.translation-only"), value: "translation-only" },
-          ]}
-        />
-      </View>
+      <Select
+        value={translationMode}
+        onValueChange={(value) => {
+          setGeneralSetting("translationMode", value as "bilingual" | "translation-only")
+        }}
+        options={[
+          { label: t("general.translation_mode.bilingual"), value: "bilingual" },
+          { label: t("general.translation_mode.translation-only"), value: "translation-only" },
+        ]}
+      />
     </GroupedInsetListCell>
   )
 }
@@ -151,6 +150,7 @@ export const GeneralScreen: NavigationControllerView = () => {
         >
           <Switch
             size="sm"
+            testID="general-ai-summary-switch"
             value={summary}
             onValueChange={(value) => {
               setGeneralSetting("summary", value)

--- a/apps/mobile/src/screens/(stack)/feeds/[feedId]/FeedScreen.tsx
+++ b/apps/mobile/src/screens/(stack)/feeds/[feedId]/FeedScreen.tsx
@@ -36,7 +36,8 @@ export const FeedScreen: NavigationControllerView<{
           <FeedScreenEntryList />
           {!isSubscribed && isBizId(feedIdentifier) && (
             <Pressable
-              className="absolute left-1/2 z-10 m-2 mx-auto -translate-x-1/2 rounded-full bg-accent px-4 py-2"
+              className="absolute left-1/2 z-10 min-w-[112px] -translate-x-1/2 items-center justify-center overflow-hidden rounded-full bg-accent px-5 py-3"
+              hitSlop={12}
               style={{
                 bottom: Math.max(20, insets.bottom + 12),
               }}


### PR DESCRIPTION
## Summary
- replace the custom mobile switch with the native platform switch for faster, more consistent interaction
- fix the Discover category cards on iOS 26 by rendering stable emoji assets instead of relying on broken system emoji glyphs
- restore the floating follow CTA styling on feed detail and improve truncation/layout for General settings selects

## Testing
- `cd apps/mobile && pnpm run typecheck`
- `cd apps/mobile && pnpm run e2e:doctor`
- `npm exec eslint -- 'apps/mobile/src/components/ui/switch/Switch.tsx' 'apps/mobile/src/modules/discover/Category.tsx' 'apps/mobile/src/screens/(stack)/feeds/[feedId]/FeedScreen.tsx' 'apps/mobile/src/modules/settings/routes/General.tsx' 'apps/mobile/src/components/ui/form/Select.tsx' 'apps/mobile/src/components/ui/form/Select.android.tsx'`
- built a release iOS simulator app and validated the updated screens on an isolated iOS 26.3 simulator

## Notes
- Maestro view hierarchy timed out on iOS 26.3, so the final screenshot validation used coordinate-driven navigation plus `simctl` screenshots.
