### PR TITLE
chore(desktop): improve local packaging and auth debugging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ This isn’t just another app. Folo is a community — introducing a new era of 
 
 You are welcome to join the open source community to build together, please check our [Contributing Guide](./CONTRIBUTING.md) for more details.
 
+## 📦 Local desktop packaging
+
+For local macOS desktop packaging, verification, and troubleshooting, see:
+
+- [Desktop Local Packaging](./wiki/desktop-local-packaging.md)
+
 ## 🔏 Code signing policy
 
 Folo for Windows uses free code signing provided by [SignPath.io](https://about.signpath.io/), a certificate by [SignPath Foundation](https://signpath.org/).

--- a/apps/desktop/forge.config.cts
+++ b/apps/desktop/forge.config.cts
@@ -18,6 +18,7 @@ import { rimraf, rimrafSync } from "rimraf"
 
 const ResolvedMakerAppImage: typeof MakerAppImage = (MakerAppImage as any).default || MakerAppImage
 const platform = process.argv.find((arg) => arg.startsWith("--platform"))?.split("=")[1]
+const targetPlatform = platform || process.platform
 const mode = process.argv.find((arg) => arg.startsWith("--mode"))?.split("=")[1]
 const isMicrosoftStore =
   process.argv.find((arg) => arg.startsWith("--ms"))?.split("=")[1] === "true"
@@ -95,6 +96,48 @@ const noopAfterCopy = (_buildPath, _electronVersion, _platform, _arch, callback)
 
 const ignorePattern = new RegExp(`^/node_modules/(?!${[...keepModules].join("|")})`)
 
+const osxSign =
+  targetPlatform === "darwin"
+    ? process.env.OSX_SIGN_IDENTITY
+      ? {
+          optionsForFile: () => ({
+            entitlements: "build/entitlements.mac.plist",
+          }),
+          keychain: process.env.OSX_SIGN_KEYCHAIN_PATH,
+          identity: process.env.OSX_SIGN_IDENTITY,
+          continueOnError: false,
+        }
+      : {
+          // Local macOS builds still need a valid ad-hoc signature after Electron Packager
+          // mutates the upstream Electron bundle (plist updates, helper renames, extra resources).
+          // Hardened Runtime requires consistent Team IDs across loaded code, which ad-hoc signing
+          // does not provide, so local unsigned builds must disable it explicitly.
+          optionsForFile: () => ({
+            entitlements: "build/entitlements.mac.plist",
+            hardenedRuntime: false,
+          }),
+          identity: "-",
+          identityValidation: false,
+          continueOnError: false,
+        }
+    : targetPlatform === "mas"
+      ? {
+          optionsForFile: (filePath: string) => {
+            const entitlements = filePath.includes(".app/")
+              ? "build/entitlements.mas.child.plist"
+              : "build/entitlements.mas.plist"
+            return {
+              hardenedRuntime: false,
+              entitlements,
+            }
+          },
+          keychain: process.env.OSX_SIGN_KEYCHAIN_PATH,
+          identity: process.env.OSX_SIGN_IDENTITY,
+          provisioningProfile: process.env.OSX_SIGN_PROVISIONING_PROFILE_PATH,
+          continueOnError: false,
+        }
+      : undefined
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: isStaging ? "Folo Staging" : "Folo",
@@ -128,25 +171,7 @@ const config: ForgeConfig = {
     extendInfo: {
       ITSAppUsesNonExemptEncryption: false,
     },
-    osxSign: {
-      optionsForFile:
-        platform === "mas"
-          ? (filePath) => {
-              const entitlements = filePath.includes(".app/")
-                ? "build/entitlements.mas.child.plist"
-                : "build/entitlements.mas.plist"
-              return {
-                hardenedRuntime: false,
-                entitlements,
-              }
-            }
-          : () => ({
-              entitlements: "build/entitlements.mac.plist",
-            }),
-      keychain: process.env.OSX_SIGN_KEYCHAIN_PATH,
-      identity: process.env.OSX_SIGN_IDENTITY,
-      provisioningProfile: process.env.OSX_SIGN_PROVISIONING_PROFILE_PATH,
-    },
+    ...(osxSign && { osxSign }),
     ...(process.env.APPLE_ID &&
       process.env.APPLE_PASSWORD &&
       process.env.APPLE_TEAM_ID && {

--- a/apps/desktop/layer/main/src/updater/configs.ts
+++ b/apps/desktop/layer/main/src/updater/configs.ts
@@ -8,12 +8,12 @@ export const appUpdaterConfig = {
   enableCoreUpdate: !isStoreDistribution,
 
   // Disable app update will also disable renderer hot update and core update
-  enableAppUpdate: true,
+  enableAppUpdate: !DEV,
   enableDistributionStoreUpdate: isStoreDistribution,
 
   app: {
-    autoCheckUpdate: true,
-    autoDownloadUpdate: true,
+    autoCheckUpdate: !DEV,
+    autoDownloadUpdate: !DEV,
     checkUpdateInterval: 15 * 60 * 1000,
   },
 }

--- a/apps/desktop/layer/renderer/src/hooks/biz/useEntryActions.tsx
+++ b/apps/desktop/layer/renderer/src/hooks/biz/useEntryActions.tsx
@@ -271,6 +271,26 @@ export const useEntryActions = ({ entryId, view }: { entryId: string; view: Feed
 
     const configs: EntryActionItem[] = [
       new EntryActionMenuItem({
+        id: COMMAND_ID.entry.readAbove,
+        onClick: runCmdFn(COMMAND_ID.entry.readAbove, [{ publishedAt: entry.publishedAt }]),
+        hide: !!isCollection,
+        entryId,
+      }),
+      new EntryActionMenuItem({
+        id: COMMAND_ID.entry.readBelow,
+        onClick: runCmdFn(COMMAND_ID.entry.readBelow, [{ publishedAt: entry.publishedAt }]),
+        hide: !!isCollection,
+        entryId,
+      }),
+      new EntryActionMenuItem({
+        id: COMMAND_ID.entry.read,
+        onClick: runCmdFn(COMMAND_ID.entry.read, [{ entryId }]),
+        hide: !!isCollection,
+        active: !!entry.read,
+        shortcut: shortcuts[COMMAND_ID.entry.read],
+        entryId,
+      }),
+      new EntryActionMenuItem({
         id: COMMAND_ID.integration.saveToEagle,
         onClick: runCmdFn(COMMAND_ID.integration.saveToEagle, [{ entryId }]),
         entryId,
@@ -378,26 +398,6 @@ export const useEntryActions = ({ entryId, view }: { entryId: string; view: Feed
           ),
         active: isShowAITranslationOnce,
         disabled: userRole === UserRole.Free || userRole === UserRole.Trial,
-        entryId,
-      }),
-      new EntryActionMenuItem({
-        id: COMMAND_ID.entry.read,
-        onClick: runCmdFn(COMMAND_ID.entry.read, [{ entryId }]),
-        hide: !!isCollection,
-        active: !!entry.read,
-        shortcut: shortcuts[COMMAND_ID.entry.read],
-        entryId,
-      }),
-      new EntryActionMenuItem({
-        id: COMMAND_ID.entry.readAbove,
-        onClick: runCmdFn(COMMAND_ID.entry.readAbove, [{ publishedAt: entry.publishedAt }]),
-        hide: !!isCollection,
-        entryId,
-      }),
-      new EntryActionMenuItem({
-        id: COMMAND_ID.entry.readBelow,
-        onClick: runCmdFn(COMMAND_ID.entry.readBelow, [{ publishedAt: entry.publishedAt }]),
-        hide: !!isCollection,
         entryId,
       }),
       new EntryActionMenuItem({

--- a/apps/desktop/layer/renderer/src/modules/auth/TokenModal.tsx
+++ b/apps/desktop/layer/renderer/src/modules/auth/TokenModal.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner"
 import { z } from "zod"
 
 import { oneTimeToken } from "~/lib/auth"
+import { getFetchErrorMessage } from "~/lib/error-parser"
 import { handleSessionChanges } from "~/queries/auth"
 
 const formSchema = z.object({
@@ -46,7 +47,7 @@ export const TokenModalContent = () => {
       handleSessionChanges()
     } catch (e) {
       console.error("Failed to apply one-time token:", e)
-      toast.error("Failed to apply one-time token")
+      toast.error(e instanceof Error ? getFetchErrorMessage(e) : "Failed to apply one-time token")
     } finally {
       setIsLoading(false)
     }

--- a/apps/desktop/layer/renderer/src/modules/entry-content/components/EntryPlaceholderLogo.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-content/components/EntryPlaceholderLogo.tsx
@@ -63,7 +63,7 @@ export const EntryPlaceholderLogo = () => {
       }
     >
       <i className="i-mgc-folo-bot-original size-16 text-text-tertiary" />
-      <div>Where are we off to first?</div>
+      <div>Where do we go first?</div>
       <div className="mt-4 flex flex-col gap-2">
         {buttons.map((button) => (
           <Button

--- a/wiki/desktop-local-packaging.md
+++ b/wiki/desktop-local-packaging.md
@@ -1,0 +1,241 @@
+# Desktop Local Packaging
+
+This document explains how to generate a local macOS desktop package for Folo, how to verify that the package is runnable, and how to diagnose the two issues that were already seen in this repository.
+
+## Scope
+
+- This guide is for local macOS packaging only.
+- It is intended for local verification, QA, and internal testing.
+- It does not replace the signed and notarized release flow.
+
+## Conclusion First
+
+- A local macOS build does not require an Apple signing certificate.
+- The repository now supports unsigned local packaging by using ad-hoc signing for the app bundle.
+- In the local unsigned path, Hardened Runtime is explicitly disabled so the packaged Electron app can actually launch.
+
+Relevant config:
+
+- [`apps/desktop/forge.config.cts`](/Users/dustin/.codex/worktrees/ee0b/Folo/apps/desktop/forge.config.cts)
+
+## Prerequisites
+
+1. Use the project-supported package manager:
+
+```bash
+pnpm install
+```
+
+2. Make sure your active `node` is stable during the whole packaging flow.
+
+Recommended checks:
+
+```bash
+which node
+node -v
+pnpm -v
+```
+
+3. Run packaging from the desktop app directory:
+
+```bash
+cd apps/desktop
+```
+
+## Recommended Packaging Commands
+
+For a fresh local package, use the full build:
+
+```bash
+pnpm run build:electron
+```
+
+This does two things:
+
+1. Builds the Electron app with `electron-vite`
+2. Generates distributables with `electron-forge`
+
+If you already have an up-to-date `dist/` and only want to rerun the packaging step, you can use:
+
+```bash
+pnpm run build:electron-forge
+```
+
+For macOS multi-arch packaging:
+
+```bash
+pnpm run build:electron-forge:macos
+```
+
+## Output Locations
+
+After a successful local macOS build, the main outputs are here:
+
+- App bundle:
+
+```text
+apps/desktop/out/Folo-darwin-arm64/Folo.app
+```
+
+- DMG:
+
+```text
+apps/desktop/out/make/Folo-<version>-macos-arm64.dmg
+```
+
+- ZIP:
+
+```text
+apps/desktop/out/make/zip/darwin/arm64/Folo-<version>-macos-arm64.zip
+```
+
+## Verify the Result
+
+After packaging, verify both signature integrity and actual launch.
+
+### 1. Verify code signing structure
+
+```bash
+codesign --verify --deep --strict --verbose=4 apps/desktop/out/Folo-darwin-arm64/Folo.app
+codesign --verify --strict --verbose=4 "apps/desktop/out/Folo-darwin-arm64/Folo.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework"
+spctl -a -vv apps/desktop/out/Folo-darwin-arm64/Folo.app
+```
+
+Expected result:
+
+- `codesign` should report `valid on disk`
+- `spctl` may show `accepted`
+- Local unsigned builds are expected to use `adhoc` signature
+
+### 2. Verify the app actually launches
+
+```bash
+apps/desktop/out/Folo-darwin-arm64/Folo.app/Contents/MacOS/Folo
+```
+
+If the app stays alive and prints normal application logs, the local package is runnable.
+
+## How Local Unsigned Packaging Works
+
+For local macOS builds without `OSX_SIGN_IDENTITY`:
+
+- The app is signed with ad-hoc signing using `identity: "-"`
+- Identity validation is disabled
+- Hardened Runtime is disabled
+- Signing errors are not ignored
+
+This behavior is important for two reasons:
+
+1. Electron Packager mutates the upstream Electron bundle during packaging, so the bundle must be re-signed even for local builds.
+2. If Hardened Runtime stays enabled under ad-hoc signing, `dyld` can reject `Electron Framework` at launch because there is no usable Team ID relationship.
+
+## Release Build vs Local Build
+
+### Local build
+
+- No Apple certificate required
+- No notarization required
+- Intended for local install and verification
+
+### Release build
+
+- Requires a real signing identity
+- Usually requires notarization
+- Uses the certificate-based macOS signing path
+
+## Common Problems
+
+### Problem 1: App launches and immediately crashes
+
+Example symptom:
+
+```text
+Termination Reason: Namespace CODESIGNING, Code 2
+```
+
+or:
+
+```text
+Library not loaded: @rpath/Electron Framework.framework/Electron Framework
+... mapped file (non-platform) have different Team IDs
+```
+
+Cause:
+
+- The app was packaged with an invalid or incomplete local signing setup.
+- Or Hardened Runtime was left enabled on an ad-hoc signed local build.
+
+Fix:
+
+- Rebuild using the current `forge.config.cts`
+- Regenerate the package with:
+
+```bash
+cd apps/desktop
+pnpm run build:electron
+```
+
+- Re-test the newly generated `.app`, not an older copied one
+
+### Problem 2: `macos-alias` native module ABI mismatch
+
+Example symptom:
+
+```text
+was compiled against a different Node.js version using NODE_MODULE_VERSION XXX
+This version of Node.js requires NODE_MODULE_VERSION YYY
+```
+
+Cause:
+
+- `electron-forge` is being executed by a different `node` than the one used when native dependencies were installed or rebuilt.
+
+Fix:
+
+1. Check the active node:
+
+```bash
+which node
+node -v
+```
+
+2. Rebuild the native dependency under the current node:
+
+```bash
+pnpm rebuild macos-alias
+```
+
+3. If rebuild is still inconsistent, reinstall dependencies with the intended node version:
+
+```bash
+pnpm install
+```
+
+Important:
+
+- Do not switch between multiple Node installations midway through install and packaging unless you rebuild native modules again.
+
+## Recommended Local Workflow
+
+Use this sequence for local macOS packaging:
+
+```bash
+pnpm install
+cd apps/desktop
+pnpm run build:electron
+codesign --verify --deep --strict --verbose=4 out/Folo-darwin-arm64/Folo.app
+./out/Folo-darwin-arm64/Folo.app/Contents/MacOS/Folo
+```
+
+If you only need the packaged artifacts after code is already built:
+
+```bash
+cd apps/desktop
+pnpm run build:electron-forge
+```
+
+## Notes
+
+- If you test by opening `Folo.app` in Finder, make sure you are opening the newly generated app, not an older copy from another directory.
+- For debugging local packaging issues, always trust the newest crash log and the current packaged app path together.
+- If packaging succeeds but launch still fails, inspect both `codesign -dvvv` output and the runtime stderr from `Contents/MacOS/Folo`.

--- a/wiki/desktop-login-debug-flow.md
+++ b/wiki/desktop-login-debug-flow.md
@@ -1,0 +1,254 @@
+# Desktop Login Debug Flow
+
+这份文档记录了本次在 macOS 上调通 Folo 正式包登录与 `dev:electron` 复用登录态的关键流程，目的是方便后续重复操作，不再走弯路。
+
+## 结论先说
+
+- 本地可运行的正式 `.app` 可以直接通过 `electron-forge package` 生成，不一定要等 `make` 出 DMG。
+- 这次真正跑通的链路是：
+  1. 打一个新的正式 `.app`
+  2. 放到 `/Applications/Folo.app`
+  3. 用这个正式包完成一次真实登录
+  4. 然后直接启动 `pnpm run dev:electron`
+- 这次成功登录后，会话实际落在了 `~/Library/Application Support/Folo(dev)`，而不是 `~/Library/Application Support/Folo`
+- `dev:electron` 最终已验证登录成功，主进程日志返回 `API Response: 200 OK`
+
+## 适用场景
+
+- 需要先让桌面端登录成功，再继续调试 Electron 开发版
+- 需要绕开不稳定的 one-time token 手动输入调试
+- 需要确认正式包能跑、能登录、开发版也能继承会话
+
+## 关键目录
+
+### 正式包
+
+```text
+/Applications/Folo.app
+```
+
+### 正式包本地打包产物
+
+```text
+apps/desktop/out/Folo-darwin-arm64/Folo.app
+```
+
+### 正式包默认用户数据目录
+
+```text
+~/Library/Application Support/Folo
+```
+
+### Electron 开发版用户数据目录
+
+```text
+~/Library/Application Support/Folo(dev)
+```
+
+## 推荐流程
+
+### 1. 打一个新的正式 `.app`
+
+在桌面端目录执行：
+
+```bash
+cd apps/desktop
+CI=1 pnpm exec electron-forge package --platform=darwin --arch=arm64
+```
+
+说明：
+
+- 这个命令只产出 `.app`
+- 不走 `electron-forge make`
+- 可以避开 DMG / ZIP 阶段可能出现的长时间卡住问题
+
+### 2. 用新产物替换 `/Applications/Folo.app`
+
+建议保留旧包备份，再覆盖：
+
+```bash
+NEW_APP="/absolute/path/to/apps/desktop/out/Folo-darwin-arm64/Folo.app"
+APP_DST="/Applications/Folo.app"
+STAMP=$(date +%Y%m%d-%H%M%S)
+
+if [ -d "$APP_DST" ]; then
+  mv "$APP_DST" "/Applications/Folo.app.bak-$STAMP"
+fi
+
+/usr/bin/ditto "$NEW_APP" "$APP_DST"
+codesign --verify --deep --strict --verbose=2 "$APP_DST"
+```
+
+验签通过后，说明这个 `.app` 至少在代码签名层面可用。
+
+### 3. 用正式包完成一次真实登录
+
+直接打开：
+
+```text
+/Applications/Folo.app
+```
+
+然后正常完成登录流程。
+
+### 4. 启动开发版 Electron
+
+```bash
+cd apps/desktop
+pnpm run dev:electron
+```
+
+如果一切正常，开发版主进程日志里应该看到：
+
+```text
+API Response: 200 OK
+```
+
+如果还是未登录，主进程通常会出现：
+
+```text
+API Response: 401 Unauthorized
+```
+
+## 本次实际验证结果
+
+本次调试中，最终确认如下：
+
+- 正式包可以正常启动
+- 用户完成登录后
+- 有效会话 cookie 实际写入了：
+
+```text
+~/Library/Application Support/Folo(dev)/Cookies
+```
+
+而不是：
+
+```text
+~/Library/Application Support/Folo/Cookies
+```
+
+最终在 `Folo(dev)` 里查到了真实会话：
+
+```text
+api.folo.is | __Secure-better-auth.session_token
+```
+
+所以对调试来说，最关键的不是“理论上哪个目录应该存登录态”，而是要实际检查 cookie 落到了哪个目录。
+
+## 如何验证登录态
+
+### 1. 检查开发版目录是否已有 session cookie
+
+```bash
+sqlite3 "$HOME/Library/Application Support/Folo(dev)/Cookies" \
+  "select host_key,name,length(value),length(encrypted_value),is_httponly,is_secure \
+   from cookies where name='__Secure-better-auth.session_token';"
+```
+
+如果有结果，说明开发版目录已经存在可用登录态。
+
+### 2. 检查正式包目录
+
+```bash
+sqlite3 "$HOME/Library/Application Support/Folo/Cookies" \
+  "select host_key,name,length(value),length(encrypted_value),is_httponly,is_secure \
+   from cookies where name='__Secure-better-auth.session_token';"
+```
+
+如果这里没有结果，不代表登录没成功，只代表登录态没有落在这个目录。
+
+### 3. 通过运行日志判断是否登录成功
+
+开发版或正式包启动后，关注主进程日志：
+
+- 成功：
+
+```text
+API Response: 200 OK
+```
+
+- 未登录：
+
+```text
+API Response: 401 Unauthorized
+```
+
+## one-time token 调试的结论
+
+本次调试也确认了 one-time token 的几个关键事实：
+
+- 网页登录页生成的是一次性 token
+- Electron 收到 deeplink 后，默认会立刻自动 apply
+- 同一个 token 一旦被自动消费，再手动贴到输入框里，失败是预期行为
+
+这也是为什么后面改成“先用正式包完成真实登录，再调开发版”会更稳。
+
+## 手动接管模式说明
+
+之前为了调试 deeplink token，主进程里加过一个本地开关文件：
+
+```text
+~/Library/Application Support/Folo/debug/manual-auth-token-mode
+```
+
+它存在时：
+
+- deeplink 里的 token 仍然会落盘
+- 但不会自动调用 `applyOneTimeToken(token)`
+
+恢复正常行为时，只需要删除这个文件。
+
+## 这次踩过的坑
+
+### 1. 不要直接热替换安装版 `app.asar`
+
+曾经尝试过直接替换：
+
+```text
+/Applications/Folo.app/Contents/Resources/app.asar
+```
+
+这会触发 Electron 的 asar integrity 校验失败，应用启动即崩。
+
+结论：
+
+- 不要直接手改安装版 `app.asar`
+- 正确做法是重新跑 `electron-forge package`
+
+### 2. `codesign --verify` 通过，不代表 Electron 一定能启动
+
+光看 macOS 代码签名通过还不够，Electron 还会校验自己的 `asar integrity`。
+
+所以验证时要做两件事：
+
+1. `codesign --verify`
+2. 真实启动 `.app`
+
+### 3. `dev:web` 不适合继续追 one-time token 手动输入
+
+虽然 `dev:web` 和当前仓库默认配置大概率仍然指向生产的 `api/web` 地址，但这条链路受一次性 token 消费、deeplink、会话写入时机等因素影响较多，不适合作为首选验证路径。
+
+更稳的路径仍然是：
+
+1. 正式包真实登录
+2. 再切回 `dev:electron`
+
+## 当前更稳的调试策略
+
+后续如果还要继续调桌面端登录相关问题，优先用下面这条：
+
+1. 先重新打正式 `.app`
+2. 放到 `/Applications/Folo.app`
+3. 用正式包真实登录
+4. 检查登录态到底落在 `Folo` 还是 `Folo(dev)`
+5. 启动 `pnpm run dev:electron`
+6. 用主进程日志里的 `200 OK / 401 Unauthorized` 作为最终判断
+
+## 相关文件
+
+- [`apps/desktop/forge.config.cts`](/Users/dustin/.codex/worktrees/ee0b/Folo/apps/desktop/forge.config.cts)
+- [`apps/desktop/layer/main/src/manager/bootstrap.ts`](/Users/dustin/.codex/worktrees/ee0b/Folo/apps/desktop/layer/main/src/manager/bootstrap.ts)
+- [`apps/desktop/layer/main/src/updater/configs.ts`](/Users/dustin/.codex/worktrees/ee0b/Folo/apps/desktop/layer/main/src/updater/configs.ts)
+- [`apps/desktop/layer/renderer/src/modules/auth/TokenModal.tsx`](/Users/dustin/.codex/worktrees/ee0b/Folo/apps/desktop/layer/renderer/src/modules/auth/TokenModal.tsx)
+- [`wiki/desktop-local-packaging.md`](/Users/dustin/.codex/worktrees/ee0b/Folo/wiki/desktop-local-packaging.md)


### PR DESCRIPTION
## Summary\n- support local macOS desktop packaging without a signing identity\n- disable app update checks in desktop dev mode\n- document local packaging and desktop login debugging flow\n\n## Testing\n- pnpm run typecheck