### PR TITLE
fix(mobile): preserve pitch for Android video playback

### DIFF
--- a/apps/mobile/src/components/ui/video/VideoPlayer.tsx
+++ b/apps/mobile/src/components/ui/video/VideoPlayer.tsx
@@ -28,6 +28,7 @@ export function VideoPlayer({
   const player = useVideoPlayer(source, (player) => {
     player.loop = true
     player.muted = true
+    player.preservesPitch = true
     // player.play()
   })
   const { status } = useEvent(player, "statusChange", { status: player.status })

--- a/apps/mobile/src/modules/entry-list/templates/EntryNormalItem.tsx
+++ b/apps/mobile/src/modules/entry-list/templates/EntryNormalItem.tsx
@@ -187,7 +187,9 @@ const ThumbnailImage = ({ entryId }: { entryId: string }) => {
   const audioState = useAudioPlayState(audio?.url)
   const video = mediaModel?.type === "video" ? mediaModel : null
   const videoViewRef = useRef<null | VideoView>(null)
-  const videoPlayer = useVideoPlayer(video?.url ?? "")
+  const videoPlayer = useVideoPlayer(video?.url ?? "", (player) => {
+    player.preservesPitch = true
+  })
   const [showVideoNativeControlsForAndroid, setShowVideoNativeControlsForAndroid] = useState(false)
   const handlePressPlay = useCallback(() => {
     if (video) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Playback speed does not preserve the pitch of the video in certain contexts, specifically when tapping on a video directly from the feed. This fix just preserves the pitch after tapping on the video directly and increasing the playback speed to anything other than the normal playback speed.

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)
Placed as video instead below.
### Demo Video (if new feature)

https://github.com/user-attachments/assets/95c442e8-ff6a-4537-aa1f-501f0279a8af
> Video shows before and after the fix. The fixed version in the dev build comes at the 12 second mark.

### Linked Issues

None. Was just something I noticed that annoyed me, so I wanted to fix it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
