### PR TITLE
fix(cli): verify browser login callback token

### DIFF
--- a/apps/cli/src/browser-login.test.ts
+++ b/apps/cli/src/browser-login.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_VALUES } from "../../../packages/internal/shared/src/env.common"
-import { resolveCLILoginUrl } from "./browser-login"
+import { resolveBrowserLoginToken, resolveCLILoginUrl } from "./browser-login"
+import { CLIError } from "./output"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
 
 describe("browser login helpers", () => {
   it("maps production API URL using env.common", () => {
@@ -43,6 +49,105 @@ describe("browser login helpers", () => {
   it("throws for invalid api url", () => {
     expect(() => resolveCLILoginUrl("not-a-url", "http://127.0.0.1:3333/callback")).toThrowError(
       /Invalid API URL/,
+    )
+  })
+
+  it("exchanges one-time token for a session token", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          session: { token: "session-token" },
+          user: { id: "user-1" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const token = await resolveBrowserLoginToken(DEFAULT_VALUES.PROD.API_URL, "one-time-token")
+
+    expect(token).toBe("session-token")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.folo.is/better-auth/one-time-token/verify",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ token: "one-time-token" }),
+      }),
+    )
+  })
+
+  it("falls back when the callback already contains a session token", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Invalid token" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            session: { id: "session-1" },
+            user: { id: "user-1" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const token = await resolveBrowserLoginToken(DEFAULT_VALUES.PROD.API_URL, "session-token")
+
+    expect(token).toBe("session-token")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.folo.is/better-auth/get-session",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer session-token",
+          Cookie:
+            "__Secure-better-auth.session_token=session-token; better-auth.session_token=session-token",
+        }),
+      }),
+    )
+  })
+
+  it("surfaces verification failures when neither token path works", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Token expired" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Unauthorized" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      resolveBrowserLoginToken(DEFAULT_VALUES.PROD.API_URL, "expired-token"),
+    ).rejects.toEqual(
+      new CLIError("UNAUTHORIZED", "Browser login token verification failed: Token expired"),
+    )
+  })
+
+  it("throws invalid argument for malformed api url", async () => {
+    await expect(resolveBrowserLoginToken("not-a-url", "token")).rejects.toEqual(
+      new CLIError("INVALID_ARGUMENT", "Invalid API URL: not-a-url"),
     )
   })
 })

--- a/apps/cli/src/browser-login.ts
+++ b/apps/cli/src/browser-login.ts
@@ -8,6 +8,8 @@ import { CLIError } from "./output"
 const LOCAL_CALLBACK_HOST = "127.0.0.1"
 const LOCAL_CALLBACK_PATH = "/callback"
 const DEFAULT_TIMEOUT_MS = 3 * 60 * 1000
+const ONE_TIME_TOKEN_VERIFY_PATH = "/better-auth/one-time-token/verify"
+const SESSION_CHECK_PATH = "/better-auth/get-session"
 
 const mappedWebOrigins: Array<{ apiOrigin: string; webOrigin: string }> = [
   {
@@ -97,6 +99,107 @@ export const resolveCLILoginUrl = (apiUrl: string, callbackUrl: string): string 
   return webUrl.toString()
 }
 
+const resolveAuthEndpointUrl = (apiUrl: string, path: string): string => {
+  let api: URL
+  try {
+    api = new URL(apiUrl)
+  } catch {
+    throw new CLIError("INVALID_ARGUMENT", `Invalid API URL: ${apiUrl}`)
+  }
+
+  return new URL(path, api.origin).toString()
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+const extractErrorMessage = async (response: Response): Promise<string | undefined> => {
+  const contentType = response.headers.get("content-type") ?? ""
+
+  if (contentType.includes("application/json")) {
+    const data = (await response.json().catch(() => null)) as unknown
+    if (isRecord(data) && typeof data.message === "string" && data.message.length > 0) {
+      return data.message
+    }
+    return undefined
+  }
+
+  const text = await response.text().catch(() => "")
+  return text || undefined
+}
+
+const hasValidSessionToken = async (apiUrl: string, token: string): Promise<boolean> => {
+  const response = await fetch(resolveAuthEndpointUrl(apiUrl, SESSION_CHECK_PATH), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Cookie: `__Secure-better-auth.session_token=${token}; better-auth.session_token=${token}`,
+    },
+    method: "GET",
+  })
+
+  if (!response.ok) {
+    return false
+  }
+
+  const data = (await response.json().catch(() => null)) as unknown
+  return isRecord(data) && Boolean(data.user) && Boolean(data.session)
+}
+
+export const resolveBrowserLoginToken = async (apiUrl: string, token: string): Promise<string> => {
+  const verifyUrl = resolveAuthEndpointUrl(apiUrl, ONE_TIME_TOKEN_VERIFY_PATH)
+
+  let response: Response
+  try {
+    response = await fetch(verifyUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ token }),
+    })
+  } catch (error) {
+    throw new CLIError(
+      "NETWORK_ERROR",
+      `Failed to verify browser login token: ${(error as Error).message}`,
+    )
+  }
+
+  if (response.ok) {
+    const data = (await response.json().catch(() => null)) as unknown
+    const sessionToken =
+      isRecord(data) && isRecord(data.session) && typeof data.session.token === "string"
+        ? data.session.token
+        : undefined
+
+    if (!sessionToken) {
+      throw new CLIError(
+        "UNAUTHORIZED",
+        "Browser login verification succeeded without returning a session token.",
+      )
+    }
+
+    return sessionToken
+  }
+
+  const errorMessage = await extractErrorMessage(response)
+
+  try {
+    if (await hasValidSessionToken(apiUrl, token)) {
+      return token
+    }
+  } catch {
+    // Ignore fallback probe failures and surface the original verification error below.
+  }
+
+  throw new CLIError(
+    "UNAUTHORIZED",
+    errorMessage
+      ? `Browser login token verification failed: ${errorMessage}`
+      : "Browser login token verification failed.",
+  )
+}
+
 export interface BrowserLoginOptions {
   apiUrl: string
   timeoutMs?: number
@@ -166,13 +269,22 @@ export const loginWithBrowser = async (
         : ""
       const loginUrl = resolveCLILoginUrl(options.apiUrl, callbackUrl)
 
-      settle(() => {
-        resolve({
-          token,
-          callbackUrl,
-          loginUrl,
-        })
-      })
+      void (async () => {
+        try {
+          const sessionToken = await resolveBrowserLoginToken(options.apiUrl, token)
+          settle(() => {
+            resolve({
+              token: sessionToken,
+              callbackUrl,
+              loginUrl,
+            })
+          })
+        } catch (error) {
+          settle(() => {
+            reject(error)
+          })
+        }
+      })()
     })
 
     server.once("error", (error) => {


### PR DESCRIPTION
### Description

Fix CLI browser login so SSR callback tokens are verified through Better Auth before storing them as CLI session tokens. This keeps the existing loopback callback flow while correctly exchanging one-time tokens and still accepting callbacks that already contain a session token. Add regression coverage for the exchange, fallback, invalid API URL, and failure cases.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

N/A

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

Tests run: `pnpm --filter folocli typecheck`, `pnpm exec eslint apps/cli/src/browser-login.ts apps/cli/src/browser-login.test.ts`, `pnpm exec prettier --check apps/cli/src/browser-login.ts apps/cli/src/browser-login.test.ts`, and `pnpm --filter folocli test`.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
