### PR TITLE
fix(mobile): show Stripe subscriptions on Android

### DIFF
--- a/apps/mobile/src/lib/payment.ts
+++ b/apps/mobile/src/lib/payment.ts
@@ -28,5 +28,4 @@ export const isAndroidApkInstall = () => {
   }
 }
 
-export const isPaymentFeatureEnabled = (paymentEnabled?: boolean | null) =>
-  Boolean(paymentEnabled) && (!isAndroid || isAndroidApkInstall())
+export const isPaymentFeatureEnabled: (paymentEnabled?: boolean | null) => boolean = Boolean


### PR DESCRIPTION
### Description

Show the subscription entry and upgrade flow on all Android installs, including Google Play. This removes the Android installer gate from `isPaymentFeatureEnabled`, so mobile still respects `PAYMENT_ENABLED` while Android uses the existing Stripe checkout flow.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

Validated with `pnpm run typecheck`, `pnpm run lint:fix`, and `pnpm run test`.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
