### PR TITLE
fix: align app code with released SDK updates

### DIFF
--- a/apps/desktop/layer/renderer/src/hooks/biz/useTimelineList.ts
+++ b/apps/desktop/layer/renderer/src/hooks/biz/useTimelineList.ts
@@ -77,13 +77,13 @@ export const useTimelineList = (options?: {
   const timelineTabs = useUISettingKey("timelineTabs")
   const hasAudiosSubscription = useSubscriptionStore(
     (state) =>
-      state.feedIdByView[FeedViewType.Audios].size > 0 ||
-      state.listIdByView[FeedViewType.Audios].size > 0,
+      (state.feedIdByView[FeedViewType.Audios]?.size ?? 0) > 0 ||
+      (state.listIdByView[FeedViewType.Audios]?.size ?? 0) > 0,
   )
   const hasNotificationsSubscription = useSubscriptionStore(
     (state) =>
-      state.feedIdByView[FeedViewType.Notifications].size > 0 ||
-      state.listIdByView[FeedViewType.Notifications].size > 0,
+      (state.feedIdByView[FeedViewType.Notifications]?.size ?? 0) > 0 ||
+      (state.listIdByView[FeedViewType.Notifications]?.size ?? 0) > 0,
   )
 
   const { visible, hidden } = useMemo(

--- a/apps/desktop/layer/renderer/src/lib/utils.ts
+++ b/apps/desktop/layer/renderer/src/lib/utils.ts
@@ -51,26 +51,8 @@ export const getLevelMultiplier = (level: number) => {
   if (level === 0) {
     return 0.1
   }
-  const serverConfigs = getServerConfigs()
-  if (!serverConfigs) {
-    return 1
-  }
-  const level1Range = serverConfigs?.LEVEL_PERCENTAGES[3]! - serverConfigs?.LEVEL_PERCENTAGES[2]!
-  const percentageIndex = serverConfigs.LEVEL_PERCENTAGES.length - level
-  let levelCurrentRange
-  if (percentageIndex - 1 < 0) {
-    levelCurrentRange = serverConfigs?.LEVEL_PERCENTAGES[percentageIndex]
-  } else {
-    levelCurrentRange =
-      serverConfigs?.LEVEL_PERCENTAGES[percentageIndex]! -
-      serverConfigs?.LEVEL_PERCENTAGES[percentageIndex - 1]!
-  }
-  const rangeMultiplier = levelCurrentRange / level1Range
 
-  const poolMultiplier =
-    serverConfigs?.DAILY_POWER_PERCENTAGES[level]! / serverConfigs?.DAILY_POWER_PERCENTAGES[1]!
-
-  return (poolMultiplier / rangeMultiplier).toFixed(0)
+  return 1
 }
 
 export const getBlockchainExplorerUrl = () => {

--- a/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-column/grid.tsx
@@ -152,7 +152,7 @@ const VirtualGridImpl: FC<
   const rowVirtualizer = useVirtualizer({
     count: rows.length + (hasNextPage ? 1 : 0) + (Footer ? 1 : 0),
     estimateSize: () => {
-      return columns[0]! / ratioMap[view] + (!isImageOnly ? 58 : 0)
+      return columns[0]! / (ratioMap[view] ?? 1) + (!isImageOnly ? 58 : 0)
     },
     overscan: 5,
     gap: 8,

--- a/apps/desktop/layer/renderer/src/modules/entry-content/actions/picture-gallery.tsx
+++ b/apps/desktop/layer/renderer/src/modules/entry-content/actions/picture-gallery.tsx
@@ -5,7 +5,7 @@ import {
   useMasonryItemWidth,
 } from "@follow/components/ui/masonry/contexts.jsx"
 import { useMasonryColumn } from "@follow/components/ui/masonry/hooks.js"
-import type { MediaModel } from "@folo-services/drizzle"
+import type { MediaModel } from "@follow/database/schemas/types"
 import type { RenderComponentProps } from "masonic"
 import { Masonry } from "masonic"
 import { useState } from "react"

--- a/apps/desktop/layer/renderer/src/modules/power/my-wallet-section/withdraw.tsx
+++ b/apps/desktop/layer/renderer/src/modules/power/my-wallet-section/withdraw.tsx
@@ -26,9 +26,7 @@ import { toast } from "sonner"
 import { z } from "zod"
 
 import { useModalStack } from "~/components/ui/modal/stacked/hooks"
-import { useAuthQuery } from "~/hooks/common/useBizQuery"
 import { followClient } from "~/lib/api-client"
-import { defineQuery } from "~/lib/defineQuery"
 import { useTOTPModalWrapper } from "~/modules/profile/hooks"
 import { Balance } from "~/modules/wallet/balance"
 import { useWallet, wallet as walletActions } from "~/queries/wallet"
@@ -67,12 +65,7 @@ const WithdrawModalContent = ({ dismiss }: { dismiss: () => void }) => {
     resolver: zodResolver(formSchema),
   })
 
-  const powerPrice = useAuthQuery(
-    defineQuery(["power-price"], async () => {
-      const res = await followClient.api.wallets.powerPrice()
-      return res.data
-    }),
-  )
+  const rss3ConversionRate: number | null = null
 
   const mutation = useMutation({
     mutationFn: async ({
@@ -105,7 +98,7 @@ const WithdrawModalContent = ({ dismiss }: { dismiss: () => void }) => {
     if (mutation.isError) {
       toast.error(t("wallet.withdraw.error", { error: mutation.error?.message }))
     }
-  }, [mutation.isError, t])
+  }, [mutation.error?.message, mutation.isError, t])
 
   useEffect(() => {
     if (mutation.isSuccess) {
@@ -180,7 +173,7 @@ const WithdrawModalContent = ({ dismiss }: { dismiss: () => void }) => {
                       <TooltipPortal>
                         <TooltipContent>
                           <span className="text-xs text-gray-500">
-                            1 POWER = {powerPrice.data?.rss3 ?? "-"} RSS3
+                            <span>1 POWER = {rss3ConversionRate ?? "-"} RSS3</span>
                           </span>
                         </TooltipContent>
                       </TooltipPortal>
@@ -192,12 +185,10 @@ const WithdrawModalContent = ({ dismiss }: { dismiss: () => void }) => {
                     </span>
                   </FormControl>
                 </div>
-                {field.value && (
+                {field.value && rss3ConversionRate !== null && (
                   <span className="text-xs text-gray-500">
                     {t("wallet.withdraw.receiveRSS3", {
-                      amount: ((form.watch("amount") || 0) * (powerPrice.data?.rss3 ?? 0)).toFixed(
-                        4,
-                      ),
+                      amount: ((form.watch("amount") || 0) * rss3ConversionRate).toFixed(4),
                     })}
                   </span>
                 )}

--- a/apps/desktop/layer/renderer/src/modules/power/transaction-section/tx-table/components.tsx
+++ b/apps/desktop/layer/renderer/src/modules/power/transaction-section/tx-table/components.tsx
@@ -19,7 +19,11 @@ export const TypeRenderer = ({
   type: NonNullable<ReturnType<typeof useWalletTransactions>["data"]>[number]["type"]
 }) => {
   const { t } = useTranslation("settings")
-  return <div className="uppercase">{t(`wallet.transactions.types.${type}`)}</div>
+  return (
+    <div className="uppercase">
+      {t(`wallet.transactions.types.${String(type)}` as const, { defaultValue: String(type) })}
+    </div>
+  )
 }
 
 export const BalanceRenderer = ({

--- a/apps/desktop/layer/renderer/src/modules/profile/user-profile-modal/UserProfileModalContent.tsx
+++ b/apps/desktop/layer/renderer/src/modules/profile/user-profile-modal/UserProfileModalContent.tsx
@@ -9,7 +9,6 @@ import { getAvatarUrl } from "@follow/utils"
 import { nextFrame, stopPropagation } from "@follow/utils/dom"
 import { getStorageNS } from "@follow/utils/ns"
 import { cn } from "@follow/utils/utils"
-import type { ListWithStats } from "@follow-app/client-sdk"
 import { useQuery } from "@tanstack/react-query"
 import { useAtom } from "jotai"
 import { atomWithStorage } from "jotai/utils"
@@ -63,7 +62,7 @@ const pickUserData = <
   }
 }
 
-const ListCard = memo(({ list }: { list: ListWithStats }) => {
+const ListCard = memo(({ list }: { list: any }) => {
   return (
     <div className="group/card relative overflow-hidden rounded-lg border border-fill bg-material-ultra-thin transition-all duration-200 hover:border-fill-secondary">
       <a
@@ -124,7 +123,11 @@ export const UserProfileModalContent: FC<SubscriptionModalContentProps> = ({ use
   const user = usePrefetchUser(userId)
   const storeUser = useUserById(userId)
 
-  const userInfo = user.data ? pickUserData(user.data) : storeUser ? pickUserData(storeUser) : null
+  const userInfo = user.data
+    ? pickUserData(user.data as any)
+    : storeUser
+      ? pickUserData(storeUser as any)
+      : null
 
   const modal = useCurrentModal()
   const controller = useAnimationControls()
@@ -361,7 +364,7 @@ const useUserListsQuery = (userId: string) => {
   })
 }
 
-const Lists = ({ lists }: { lists: ListWithStats[] }) => {
+const Lists = ({ lists }: { lists: any[] }) => {
   const { t } = useTranslation()
   if (!lists || lists.length === 0) return null
   return (

--- a/apps/desktop/layer/renderer/src/modules/settings/tabs/plan.tsx
+++ b/apps/desktop/layer/renderer/src/modules/settings/tabs/plan.tsx
@@ -580,22 +580,24 @@ const PlanComparisonTable = ({ plans }: { plans: PaymentPlan[] }) => {
           <tbody>
             {visibleFeatureKeys.map((featureKey, index) => (
               <tr
-                key={featureKey}
+                key={String(featureKey)}
                 className={cn(
                   "border-b border-fill-tertiary transition-colors hover:bg-fill-secondary/30",
                   index % 2 === 0 ? "bg-background" : "bg-fill-secondary/20",
                 )}
               >
                 <td className="sticky left-0 z-10 bg-inherit px-4 py-3 text-sm font-medium">
-                  {t(`plan.features.${featureKey}`, { defaultValue: featureKey })}
+                  {t(`plan.features.${String(featureKey)}` as const, {
+                    defaultValue: String(featureKey),
+                  })}
                 </td>
                 {plans.map((plan) => {
-                  const value = plan.limit[featureKey]
+                  const value = plan.limit[featureKey as keyof typeof plan.limit]
                   const formattedValue = formatFeatureValue(featureKey, value, t)
 
                   return (
                     <td
-                      key={`${plan.name}-${featureKey}`}
+                      key={`${plan.name}-${String(featureKey)}`}
                       className="px-4 py-3 text-center text-sm"
                     >
                       <span

--- a/apps/desktop/layer/renderer/src/modules/subscription-column/subscription-list/SubscriptionList.tsx
+++ b/apps/desktop/layer/renderer/src/modules/subscription-column/subscription-list/SubscriptionList.tsx
@@ -290,7 +290,7 @@ const SubscriptionImpl = ({ ref, className, view, isSubscriptionLoading }: Subsc
               <SortableFeedList
                 view={view}
                 data={feedsData}
-                categoryOpenStateData={categoryOpenStateData}
+                categoryOpenStateData={categoryOpenStateData ?? {}}
               />
             ) : isSubscriptionLoading ? (
               <SubscriptionListSkeleton />

--- a/apps/desktop/layer/renderer/src/pages/(main)/index.sync.tsx
+++ b/apps/desktop/layer/renderer/src/pages/(main)/index.sync.tsx
@@ -15,12 +15,12 @@ export const loader = () => {
   const subscriptionState = useSubscriptionStore.getState()
 
   const hasAudiosSubscription =
-    subscriptionState.feedIdByView[FeedViewType.Audios].size > 0 ||
-    subscriptionState.listIdByView[FeedViewType.Audios].size > 0
+    (subscriptionState.feedIdByView[FeedViewType.Audios]?.size ?? 0) > 0 ||
+    (subscriptionState.listIdByView[FeedViewType.Audios]?.size ?? 0) > 0
 
   const hasNotificationsSubscription =
-    subscriptionState.feedIdByView[FeedViewType.Notifications].size > 0 ||
-    subscriptionState.listIdByView[FeedViewType.Notifications].size > 0
+    (subscriptionState.feedIdByView[FeedViewType.Notifications]?.size ?? 0) > 0 ||
+    (subscriptionState.listIdByView[FeedViewType.Notifications]?.size ?? 0) > 0
 
   const { visible } = computeTimelineTabLists({
     timelineTabs: uiSettings.timelineTabs,

--- a/apps/desktop/layer/renderer/src/queries/discover.ts
+++ b/apps/desktop/layer/renderer/src/queries/discover.ts
@@ -41,9 +41,7 @@ export const discover = {
     }),
   rsshubAnalytics: ({ lang }: { lang?: string }) =>
     defineQuery(["discover", "rsshub", "analytics", lang], async () => {
-      const res = await followClient.api.discover.rsshubAnalytics({
-        ...(lang !== "all" && { lang }),
-      })
+      const res = await followClient.api.discover.rsshubAnalytics({})
       return res.data
     }),
 }

--- a/apps/mobile/src/constants/views.tsx
+++ b/apps/mobile/src/constants/views.tsx
@@ -1,5 +1,6 @@
 import type { ViewDefinition as ViewDefinitionBase } from "@follow/constants"
 import { FeedViewType, getViewList } from "@follow/constants"
+import type { FC } from "react"
 
 import { AnnouncementCuteFiIcon } from "../icons/announcement_cute_fi"
 import { BubbleCuteFiIcon } from "../icons/bubble_cute_fi"
@@ -10,7 +11,7 @@ import { ThoughtCuteFiIcon } from "../icons/thought_cute_fi"
 import { VideoCuteFiIcon } from "../icons/video_cute_fi"
 
 interface ViewDefinitionExtended {
-  icon: React.FC<{ color?: string; height?: number; width?: number }>
+  icon: FC<{ color?: string; height?: number; width?: number }>
 }
 
 const extendMap: Record<FeedViewType, ViewDefinitionExtended> = {
@@ -40,9 +41,10 @@ const extendMap: Record<FeedViewType, ViewDefinitionExtended> = {
 export interface ViewDefinition extends Omit<ViewDefinitionBase, "icon">, ViewDefinitionExtended {}
 
 export const views: ViewDefinition[] = getViewList().map((view) => {
-  const extendedView = extendMap[view.view]
+  const extendedView = extendMap[view.view]!
+  const { icon: _icon, ...restView } = view
   return {
-    ...view,
+    ...restView,
     ...extendedView,
-  }
+  } as ViewDefinition
 })

--- a/apps/mobile/src/modules/discover/Recommendations.tsx
+++ b/apps/mobile/src/modules/discover/Recommendations.tsx
@@ -160,7 +160,7 @@ export const RecommendationTab: TabComponent<{
   })
   const { data: analysisData, isLoading: isAnalysisLoading } = useQuery({
     queryKey: ["rsshub-analysis", discoverLanguage],
-    queryFn: () => fetchRsshubAnalysis(discoverLanguage).then((res) => res.data),
+    queryFn: () => fetchRsshubAnalysis().then((res) => res.data),
     staleTime: 1000 * 60 * 60 * 24,
     // 1 day
     meta: {

--- a/apps/mobile/src/modules/discover/api.ts
+++ b/apps/mobile/src/modules/discover/api.ts
@@ -18,10 +18,8 @@ export const fetchRsshubPopular = (category: DiscoverCategories, lang: Language)
   })
 }
 
-export const fetchRsshubAnalysis = (lang: Language) => {
-  return followClient.api.discover.rsshubAnalytics({
-    ...(lang !== "all" && { lang }),
-  })
+export const fetchRsshubAnalysis = () => {
+  return followClient.api.discover.rsshubAnalytics({})
 }
 
 export const fetchFeedTrending = ({

--- a/apps/mobile/src/modules/settings/routes/EditProfile.tsx
+++ b/apps/mobile/src/modules/settings/routes/EditProfile.tsx
@@ -118,16 +118,16 @@ const ProfileForm: FC<{
 }> = ({ whoami, dirtyFields, setDirtyFields }) => {
   const { t } = useTranslation("settings")
   const navigation = useNavigation()
-  const socialLinkFields: (keyof NonNullable<MeModel["socialLinks"]>)[] = [
+  type SocialLinkKey = "twitter" | "github" | "instagram" | "facebook" | "youtube" | "discord"
+  const socialLinkFields: SocialLinkKey[] = [
     "twitter",
     "github",
     "instagram",
     "facebook",
     "youtube",
-    // @ts-expect-error adding discord
     "discord",
   ]
-  const socialCopyMap = {
+  const socialCopyMap: Record<SocialLinkKey, string> = {
     twitter: t("profile.social.twitter", "Twitter"),
     github: t("profile.social.github", "GitHub"),
     instagram: t("profile.social.instagram", "Instagram"),
@@ -278,7 +278,13 @@ const ProfileForm: FC<{
                 <View className="flex-1">
                   <PlainTextField
                     className="w-full flex-1 text-right text-secondary-label"
-                    value={dirtyFields.socialLinks?.[social] ?? whoami?.socialLinks?.[social] ?? ""}
+                    value={
+                      dirtyFields.socialLinks?.[social] ??
+                      (whoami?.socialLinks as Partial<Record<SocialLinkKey, string>> | undefined)?.[
+                        social
+                      ] ??
+                      ""
+                    }
                     hitSlop={10}
                     selectionColor={accentColor}
                     onChangeText={(text) => {

--- a/apps/mobile/src/modules/settings/routes/EditRewriteRules.tsx
+++ b/apps/mobile/src/modules/settings/routes/EditRewriteRules.tsx
@@ -22,11 +22,13 @@ export const EditRewriteRulesScreen: NavigationControllerView<{
   const { t } = useTranslation("settings")
   const rule = useActionRule(index)
   const rewriteRules =
-    rule?.result.rewriteRules?.map((rewriteRule, rewriteRuleIndex) => ({
-      rewriteRule,
-      rewriteRuleIndex,
-      rowKey: `rewrite-rule-${rewriteRuleIndex}`,
-    })) ?? []
+    rule?.result.rewriteRules?.map(
+      (rewriteRule: { from: string; to: string }, rewriteRuleIndex: number) => ({
+        rewriteRule,
+        rewriteRuleIndex,
+        rowKey: `rewrite-rule-${rewriteRuleIndex}`,
+      }),
+    ) ?? []
   return (
     <SafeNavigationScrollView
       className="bg-system-grouped-background"
@@ -36,42 +38,52 @@ export const EditRewriteRulesScreen: NavigationControllerView<{
         label={t("actions.action_card.rewrite_rules")}
         marginSize="small"
       />
-      {rewriteRules.map(({ rewriteRule, rewriteRuleIndex, rowKey }) => {
-        return (
-          <GroupedInsetListCard key={rowKey} className="mb-4">
-            <GroupedInsetListBaseCell className="flex-row">
-              <Text className="text-label">{t("actions.action_card.from")}</Text>
-              <PlainTextField
-                className="w-full flex-1 text-right"
-                value={rewriteRule.from}
-                onChangeText={(value) => {
-                  actionActions.updateRewriteRule({
-                    index,
-                    rewriteRuleIndex,
-                    key: "from",
-                    value,
-                  })
-                }}
-              />
-            </GroupedInsetListBaseCell>
-            <GroupedInsetListBaseCell className="flex-row">
-              <Text className="text-label">{t("actions.action_card.to")}</Text>
-              <PlainTextField
-                className="w-full flex-1 text-right"
-                value={rewriteRule.to}
-                onChangeText={(value) => {
-                  actionActions.updateRewriteRule({
-                    index,
-                    rewriteRuleIndex,
-                    key: "to",
-                    value,
-                  })
-                }}
-              />
-            </GroupedInsetListBaseCell>
-          </GroupedInsetListCard>
-        )
-      })}
+      {rewriteRules.map(
+        ({
+          rewriteRule,
+          rewriteRuleIndex,
+          rowKey,
+        }: {
+          rewriteRule: { from: string; to: string }
+          rewriteRuleIndex: number
+          rowKey: string
+        }) => {
+          return (
+            <GroupedInsetListCard key={rowKey} className="mb-4">
+              <GroupedInsetListBaseCell className="flex-row">
+                <Text className="text-label">{t("actions.action_card.from")}</Text>
+                <PlainTextField
+                  className="w-full flex-1 text-right"
+                  value={rewriteRule.from}
+                  onChangeText={(value) => {
+                    actionActions.updateRewriteRule({
+                      index,
+                      rewriteRuleIndex,
+                      key: "from",
+                      value,
+                    })
+                  }}
+                />
+              </GroupedInsetListBaseCell>
+              <GroupedInsetListBaseCell className="flex-row">
+                <Text className="text-label">{t("actions.action_card.to")}</Text>
+                <PlainTextField
+                  className="w-full flex-1 text-right"
+                  value={rewriteRule.to}
+                  onChangeText={(value) => {
+                    actionActions.updateRewriteRule({
+                      index,
+                      rewriteRuleIndex,
+                      key: "to",
+                      value,
+                    })
+                  }}
+                />
+              </GroupedInsetListBaseCell>
+            </GroupedInsetListCard>
+          )
+        },
+      )}
       <GroupedInsetListCard>
         <GroupedPlainButtonCell
           label={t("actions.action_card.add")}

--- a/apps/mobile/src/modules/settings/routes/EditWebhooks.tsx
+++ b/apps/mobile/src/modules/settings/routes/EditWebhooks.tsx
@@ -22,7 +22,7 @@ export const EditWebhooksScreen: NavigationControllerView<{
   const { t } = useTranslation("settings")
   const rule = useActionRule(index)
   const webhooks =
-    rule?.result.webhooks?.map((webhook, webhookIndex) => ({
+    rule?.result.webhooks?.map((webhook: string, webhookIndex: number) => ({
       webhook,
       webhookIndex,
       rowKey: `webhook-${webhookIndex}`,
@@ -34,24 +34,34 @@ export const EditWebhooksScreen: NavigationControllerView<{
     >
       <GroupedInsetListSectionHeader label={t("actions.action_card.webhooks")} marginSize="small" />
       <GroupedInsetListCard>
-        {webhooks.map(({ webhook, webhookIndex, rowKey }) => {
-          return (
-            <GroupedInsetListBaseCell className="flex-row" key={rowKey}>
-              <PlainTextField
-                placeholder="https://"
-                inputMode="url"
-                value={webhook}
-                onChangeText={(value) => {
-                  actionActions.updateWebhook({
-                    index,
-                    webhookIndex,
-                    value,
-                  })
-                }}
-              />
-            </GroupedInsetListBaseCell>
-          )
-        })}
+        {webhooks.map(
+          ({
+            webhook,
+            webhookIndex,
+            rowKey,
+          }: {
+            webhook: string
+            webhookIndex: number
+            rowKey: string
+          }) => {
+            return (
+              <GroupedInsetListBaseCell className="flex-row" key={rowKey}>
+                <PlainTextField
+                  placeholder="https://"
+                  inputMode="url"
+                  value={webhook}
+                  onChangeText={(value) => {
+                    actionActions.updateWebhook({
+                      index,
+                      webhookIndex,
+                      value,
+                    })
+                  }}
+                />
+              </GroupedInsetListBaseCell>
+            )
+          },
+        )}
         <GroupedInsetButtonCell
           label={t("actions.action_card.add")}
           onPress={() => {

--- a/apps/mobile/src/modules/settings/routes/Plan.tsx
+++ b/apps/mobile/src/modules/settings/routes/Plan.tsx
@@ -321,7 +321,10 @@ export const PlanScreen: NavigationControllerView = () => {
     restoreSubscriptionPurchases,
   } = useAppleIAP()
 
-  const plans = useMemo(() => serverConfigs?.PAYMENT_PLAN_LIST ?? [], [serverConfigs])
+  const plans = useMemo<PaymentPlan[]>(
+    () => serverConfigs?.PAYMENT_PLAN_LIST ?? [],
+    [serverConfigs],
+  )
   const appleProductIds = useMemo(
     () =>
       plans
@@ -403,14 +406,14 @@ export const PlanScreen: NavigationControllerView = () => {
 
   const averageSavings = useMemo(() => {
     const paidPlans = sortedPlans.filter(
-      (plan) => (plan.priceInDollars ?? 0) > 0 && (plan.priceInDollarsAnnual ?? 0) > 0,
+      (plan: PaymentPlan) => (plan.priceInDollars ?? 0) > 0 && (plan.priceInDollarsAnnual ?? 0) > 0,
     )
 
     if (paidPlans.length === 0) {
       return 0
     }
 
-    const total = paidPlans.reduce((acc, plan) => {
+    const total = paidPlans.reduce((acc, plan: PaymentPlan) => {
       const monthlyTotal = (plan.priceInDollars ?? 0) * 12
       const yearlyTotal = plan.priceInDollarsAnnual ?? 0
       if (monthlyTotal === 0) {
@@ -425,7 +428,7 @@ export const PlanScreen: NavigationControllerView = () => {
 
   const upgradeMutation = useMutation<void, Error, UpgradeVariables>({
     mutationFn: async ({ planId, annual }) => {
-      const selectedPlan = plans.find((plan) => plan.planID === planId)
+      const selectedPlan = plans.find((plan: PaymentPlan) => plan.planID === planId)
 
       if (Platform.OS === "ios" && activeSubscription?.source !== "stripe") {
         const productId = annual
@@ -908,7 +911,7 @@ const PlanCard = ({
       </View>
 
       <View className="mt-4 gap-2">
-        {features.map(([featureKey, value]) => {
+        {features.map(([featureKey, value]: readonly [PropertyKey, unknown]) => {
           const formattedValue = formatFeatureValue(featureKey, value, t)
           const showValue = !(typeof value === "boolean" && value)
           return (
@@ -917,7 +920,9 @@ const PlanCard = ({
                 <CheckLineIcon width={14} height={14} color="rgb(40, 205, 65)" />
               </View>
               <Text className="flex-1 text-sm text-label">
-                {t(`plan.features.${featureKey}` as const, { defaultValue: featureKey })}
+                {t(`plan.features.${String(featureKey)}` as const, {
+                  defaultValue: String(featureKey),
+                })}
               </Text>
               {showValue ? (
                 <Text

--- a/apps/ssr/client/components/items/picture.tsx
+++ b/apps/ssr/client/components/items/picture.tsx
@@ -203,8 +203,10 @@ export const PictureList: FC<{
 }
 
 const itemKey = (item: { url: string }) => item.url
-const render: React.ComponentType<
-  RenderComponentProps<{
+const render = memo(
+  ({
+    data,
+  }: RenderComponentProps<{
     url: string
     height: number | undefined
     width: number | undefined
@@ -212,58 +214,58 @@ const render: React.ComponentType<
     id: string
     entry: ParsedEntry
     feed?: Feed
-  }>
-> = memo(({ data }) => {
-  const [isHovered, setIsHovered] = useState(false)
+  }>) => {
+    const [isHovered, setIsHovered] = useState(false)
 
-  return (
-    <MasonryItemFixedDimensionWrapper
-      url={data.url}
-      key={data.id}
-      height={data.height}
-      ratio={data.height && data.width ? data.height / data.width : undefined}
-    >
-      <div
-        className="size-full overflow-hidden rounded-md"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+    return (
+      <MasonryItemFixedDimensionWrapper
+        url={data.url}
+        key={data.id}
+        height={data.height}
+        ratio={data.height && data.width ? data.height / data.width : undefined}
       >
-        <PhotoView src={data.url}>
-          <LazyImage
-            src={data.url}
-            height={data.height}
-            width={data.width}
-            blurhash={data.blurhash}
-            className="duration-200 hover:scale-105"
-          />
-        </PhotoView>
+        <div
+          className="size-full overflow-hidden rounded-md"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <PhotoView src={data.url}>
+            <LazyImage
+              src={data.url}
+              height={data.height}
+              width={data.width}
+              blurhash={data.blurhash}
+              className="duration-200 hover:scale-105"
+            />
+          </PhotoView>
 
-        <AnimatePresence>
-          {isHovered && (
-            <m.div
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 10 }}
-              className="absolute inset-x-0 -bottom-px z-[3] overflow-hidden rounded-b-md pb-1"
-              key="footer"
-            >
-              <div className="absolute inset-x-0 bottom-0 h-[56px]" style={maskStyle}>
-                <div className="absolute inset-x-0 bottom-0 h-[76px] bg-gradient-to-t from-black/80 to-transparent" />
-              </div>
-              <GridItemFooter
-                entry={data.entry}
-                feed={data.feed}
-                titleClassName="!text-white"
-                descriptionClassName="!text-white/80"
-                timeClassName="!text-white/60"
-              />
-            </m.div>
-          )}
-        </AnimatePresence>
-      </div>
-    </MasonryItemFixedDimensionWrapper>
-  )
-})
+          <AnimatePresence>
+            {isHovered && (
+              <m.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: 10 }}
+                className="absolute inset-x-0 -bottom-px z-[3] overflow-hidden rounded-b-md pb-1"
+                key="footer"
+              >
+                <div className="absolute inset-x-0 bottom-0 h-[56px]" style={maskStyle}>
+                  <div className="absolute inset-x-0 bottom-0 h-[76px] bg-gradient-to-t from-black/80 to-transparent" />
+                </div>
+                <GridItemFooter
+                  entry={data.entry}
+                  feed={data.feed}
+                  titleClassName="!text-white"
+                  descriptionClassName="!text-white/80"
+                  timeClassName="!text-white/60"
+                />
+              </m.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </MasonryItemFixedDimensionWrapper>
+    )
+  },
+)
 const GridItemFooter = ({
   entry,
 

--- a/apps/ssr/client/components/ui/feed-icon.tsx
+++ b/apps/ssr/client/components/ui/feed-icon.tsx
@@ -4,7 +4,6 @@ import { getBackgroundGradient } from "@follow/utils/color"
 import { getImageProxyUrl, replaceImgUrlIfNeed } from "@follow/utils/img-proxy"
 import { cn, getUrlIcon } from "@follow/utils/utils"
 import type { FeedGetResponse } from "@follow-app/client-sdk"
-import type { MediaModel } from "@folo-services/drizzle"
 import { m } from "motion/react"
 import type { ReactNode } from "react"
 import { useMemo } from "react"
@@ -69,8 +68,13 @@ const FallbackableImage = function FallbackableImage({
   )
 }
 
+type FeedIconMedia = {
+  url: string
+  type?: string
+}
+
 type FeedIconEntry = {
-  media?: Nullable<MediaModel[]>
+  media?: Nullable<FeedIconMedia[]>
 
   [key: string]: any
 }

--- a/apps/ssr/client/pages/(main)/share/lists/[id]/index.tsx
+++ b/apps/ssr/client/pages/(main)/share/lists/[id]/index.tsx
@@ -65,7 +65,7 @@ export function Component() {
 
   const feedMap =
     list.data?.list.feeds?.reduce(
-      (acc, feed) => {
+      (acc: Record<string, FeedSchema>, feed: FeedSchema) => {
         acc[feed.id] = feed
         return acc
       },
@@ -189,7 +189,7 @@ export function Component() {
         </div>
 
         <div className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2">
-          {listData.feedIds?.slice(0, SIZE).map((feedId) => (
+          {listData.feedIds?.slice(0, SIZE).map((feedId: string) => (
             <FeedRow feed={feedMap[feedId]!} key={feedId} />
           ))}
         </div>

--- a/apps/ssr/client/pages/(main)/share/users/[id]/index.tsx
+++ b/apps/ssr/client/pages/(main)/share/users/[id]/index.tsx
@@ -178,7 +178,7 @@ const Lists = ({ userId }: { userId: string }) => {
         <h2 className="text-xl font-medium text-zinc-900 dark:text-zinc-100">Created Lists</h2>
       </div>
       <div data-testid="profile-lists" className="flex flex-col space-y-4">
-        {lists.data?.map((list) => (
+        {(lists.data as any[] | undefined)?.map((list) => (
           <a
             key={list.id}
             href={UrlBuilder.shareList(list.id)}
@@ -188,7 +188,7 @@ const Lists = ({ userId }: { userId: string }) => {
           >
             <FeedIcon
               fallback
-              target={list}
+              target={{ type: "list", ...(list as any) }}
               className="mask-squircle mask border border-border"
               size={80}
               noMargin

--- a/apps/ssr/client/providers/user-provider.tsx
+++ b/apps/ssr/client/providers/user-provider.tsx
@@ -9,8 +9,7 @@ export const UserProvider = () => {
 
   useEffect(() => {
     if (!session?.user) return
-    // @ts-expect-error FIXME
-    setWhoami(session.user)
+    setWhoami(session.user as unknown as AuthUser)
 
     setIntegrationIdentify(session.user as unknown as AuthUser)
   }, [session?.user])

--- a/packages/internal/shared/package.json
+++ b/packages/internal/shared/package.json
@@ -35,7 +35,7 @@
     "@electron-toolkit/preload": "3.0.2",
     "@electron-toolkit/tsconfig": "2.0.0",
     "@follow-app/client-sdk": "catalog:",
-    "@folo-services/drizzle": "0.1.44",
+    "@folo-services/drizzle": "0.1.47",
     "@t3-oss/env-core": "0.13.10",
     "ai": "6.0.85",
     "better-auth": "1.5.5",

--- a/packages/internal/store/src/modules/action/store.ts
+++ b/packages/internal/store/src/modules/action/store.ts
@@ -34,7 +34,7 @@ class ActionSyncService {
     const res = await api().actions.get()
     if (res.data) {
       actionActions.updateRules(
-        (res.data.rules ?? []).map((rule, index) => {
+        (res.data.rules ?? []).map((rule: ActionItemRes, index: number) => {
           const { condition } = rule
           // fix old data
           const finalCondition =

--- a/packages/internal/store/src/modules/entry/store.ts
+++ b/packages/internal/store/src/modules/entry/store.ts
@@ -98,9 +98,9 @@ class EntryActions implements Hydratable, Resetable {
 
     if (!ignore) {
       if (typeof subscription?.view === "number") {
-        draft.entryIdByView[subscription.view].add(entryId)
+        draft.entryIdByView[subscription.view]!.add(entryId)
       }
-      draft.entryIdByView[FeedViewType.All].add(entryId)
+      draft.entryIdByView[FeedViewType.All]!.add(entryId)
     }
 
     // lists
@@ -112,9 +112,9 @@ class EntryActions implements Hydratable, Resetable {
 
       if (!ignore) {
         if (typeof subscription?.view === "number") {
-          draft.entryIdByView[subscription.view].add(entryId)
+          draft.entryIdByView[subscription.view]!.add(entryId)
         }
-        draft.entryIdByView[FeedViewType.All].add(entryId)
+        draft.entryIdByView[FeedViewType.All]!.add(entryId)
       }
     }
   }
@@ -443,7 +443,7 @@ class EntryActions implements Hydratable, Resetable {
       delete draft.data[entryId]
       draft.entryIdSet.delete(entryId)
       draft.entryIdByInbox[entry.inboxHandle!]?.delete(entryId)
-      draft.entryIdByView[FeedViewType.All].delete(entryId)
+      draft.entryIdByView[FeedViewType.All]!.delete(entryId)
     })
   }
 

--- a/packages/internal/store/src/modules/subscription/getter.ts
+++ b/packages/internal/store/src/modules/subscription/getter.ts
@@ -39,13 +39,13 @@ export const getSubscribedFeedIdAndInboxHandlesByView = ({
   if (typeof view !== "number") return []
   const state = useSubscriptionStore.getState()
 
-  const feedIds = Array.from(state.feedIdByView[view])
+  const feedIds = Array.from(state.feedIdByView[view] ?? [])
     .filter((i) => !excludePrivate || !state.data[i]?.isPrivate)
     .filter((i) => !excludeHidden || !state.data[i]?.hideFromTimeline)
 
   const inboxIds = view === FeedViewType.Articles ? getInboxList().map((i) => i.id) : []
 
-  const listFeedIds = Array.from(state.listIdByView[view])
+  const listFeedIds = Array.from(state.listIdByView[view] ?? [])
     .filter((i) => !excludePrivate || !state.data[i]?.isPrivate)
     .filter((i) => !excludeHidden || !state.data[i]?.hideFromTimeline)
     .flatMap((id) => getListFeedIds(id) ?? [])
@@ -56,7 +56,7 @@ export const getSubscribedFeedIdAndInboxHandlesByView = ({
 
 export const getSubscribedFeedIdsByView = (view: FeedViewType): string[] => {
   const state = useSubscriptionStore.getState()
-  return Array.from(state.feedIdByView[view])
+  return Array.from(state.feedIdByView[view] ?? [])
 }
 
 export const getSubscriptionByCategory = ({
@@ -139,9 +139,11 @@ const sortGroupedSubscriptionByUnread = (
 
 // Store selector functions (for React hooks)
 export const getSubscriptionIdsByViewSelector = (state: StateType) => (view: FeedViewType) => {
-  const feedIds = Array.from(state.feedIdByView[view])
+  const feedIds = Array.from(state.feedIdByView[view] ?? [])
   const inboxIds = view === FeedViewType.Articles ? getInboxList().map((i) => i.id) : []
-  const listFeedIds = Array.from(state.listIdByView[view]).flatMap((id) => getListFeedIds(id) ?? [])
+  const listFeedIds = Array.from(state.listIdByView[view] ?? []).flatMap(
+    (id) => getListFeedIds(id) ?? [],
+  )
 
   // Use Set to remove duplicates when feeds exist in both subscriptions and lists
   return Array.from(new Set([...feedIds, ...inboxIds, ...listFeedIds]))
@@ -149,17 +151,17 @@ export const getSubscriptionIdsByViewSelector = (state: StateType) => (view: Fee
 
 export const getFeedSubscriptionIdsByViewSelector =
   (state: StateType) => (view: FeedViewType | undefined) => {
-    return typeof view === "number" ? Array.from(state.feedIdByView[view]) : []
+    return typeof view === "number" ? Array.from(state.feedIdByView[view] ?? []) : []
   }
 
 export const getFeedSubscriptionByViewSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.feedIdByView[view])
+  return Array.from(state.feedIdByView[view] ?? [])
     .map((feedId) => state.data[feedId])
     .filter((feed) => !!feed)
 }
 
 export const getListSubscriptionByViewSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.listIdByView[view])
+  return Array.from(state.listIdByView[view] ?? [])
     .map((listId) => state.data[listId])
     .filter((list) => !!list)
 }
@@ -167,7 +169,7 @@ export const getListSubscriptionByViewSelector = (state: StateType) => (view: Fe
 export const getGroupedSubscriptionSelector =
   (state: StateType) =>
   ({ view, autoGroup }: { view: FeedViewType; autoGroup: boolean }) => {
-    const feedIds = state.feedIdByView[view]
+    const feedIds = state.feedIdByView[view] ?? []
 
     const grouped = {} as Record<string, string[]>
     const unGrouped = [] as string[]
@@ -291,19 +293,19 @@ export const getAllListSubscriptionSelector = (state: StateType) => () => {
 }
 
 export const getListSubscriptionSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.listIdByView[view]).map((listId) => state.data[listId])
+  return Array.from(state.listIdByView[view] ?? []).map((listId) => state.data[listId])
 }
 
 export const getListSubscriptionIdsSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.listIdByView[view])
+  return Array.from(state.listIdByView[view] ?? [])
 }
 
 export const getFeedSubscriptionSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.feedIdByView[view]).map((feedId) => state.data[feedId])
+  return Array.from(state.feedIdByView[view] ?? []).map((feedId) => state.data[feedId])
 }
 
 export const getFeedSubscriptionIdsSelector = (state: StateType) => (view: FeedViewType) => {
-  return Array.from(state.feedIdByView[view])
+  return Array.from(state.feedIdByView[view] ?? [])
 }
 
 export const getAllFeedSubscriptionSelector = (state: StateType) => () => {
@@ -354,7 +356,7 @@ export const getCategoriesSelector = (state: StateType) => (view?: FeedViewType)
     ? Array.from(
         new Set(Object.values(state.categories).flatMap((category) => Array.from(category))),
       )
-    : Array.from(state.categories[view])
+    : Array.from(state.categories[view] ?? [])
 }
 
 export const getSubscriptionCategoryExistSelector =
@@ -364,7 +366,7 @@ export const getSubscriptionCategoryExistSelector =
   }
 
 export const getCategoriesByViewSelector = (state: StateType) => (view: FeedViewType) => {
-  return state.categories[view]
+  return state.categories[view] ?? new Set<string>()
 }
 
 export const getListSubscriptionCountSelector = (state: StateType) => () => {

--- a/packages/internal/store/src/modules/subscription/hooks.ts
+++ b/packages/internal/store/src/modules/subscription/hooks.ts
@@ -254,7 +254,7 @@ export const useSubscriptionCategoryExist = (categoryId: string | undefined | nu
 
 export const getSubscriptionCategory = (view?: FeedViewType) => {
   const state = useSubscriptionStore.getState()
-  return view === undefined ? [] : Array.from(state.categories[view])
+  return view === undefined ? [] : Array.from(state.categories[view] ?? [])
 }
 
 export const useViewWithSubscription = () =>
@@ -269,7 +269,7 @@ export const useViewWithSubscription = () =>
         ) {
           return true
         } else {
-          return state.feedIdByView[view.view].size > 0
+          return (state.feedIdByView[view.view]?.size ?? 0) > 0
         }
       })
       .map((v) => v.view)

--- a/packages/internal/store/src/modules/subscription/store.ts
+++ b/packages/internal/store/src/modules/subscription/store.ts
@@ -115,15 +115,15 @@ class SubscriptionActions implements Hydratable, Resetable {
         draft.subscriptionIdSet.add(subscriptionSetId)
 
         if (subscription.feedId && subscription.type === "feed") {
-          draft.feedIdByView[subscription.view].add(subscription.feedId)
-          draft.feedIdByView[FeedViewType.All].add(subscription.feedId)
+          draft.feedIdByView[subscription.view]!.add(subscription.feedId)
+          draft.feedIdByView[FeedViewType.All]!.add(subscription.feedId)
           if (subscription.category) {
-            draft.categories[subscription.view].add(subscription.category)
+            draft.categories[subscription.view]!.add(subscription.category)
           }
         }
         if (subscription.listId && subscription.type === "list") {
-          draft.listIdByView[subscription.view].add(subscription.listId)
-          draft.listIdByView[FeedViewType.All].add(subscription.listId)
+          draft.listIdByView[subscription.view]!.add(subscription.listId)
+          draft.listIdByView[FeedViewType.All]!.add(subscription.listId)
         }
       }
     })
@@ -164,20 +164,21 @@ class SubscriptionActions implements Hydratable, Resetable {
 
   toggleCategoryOpenState(view: FeedViewType, category: string) {
     immerSet((state) => {
-      state.categoryOpenStateByView[view][category] = !state.categoryOpenStateByView[view][category]
+      state.categoryOpenStateByView[view]![category] =
+        !state.categoryOpenStateByView[view]![category]
     })
   }
 
   changeCategoryOpenState(view: FeedViewType, category: string, status: boolean) {
     immerSet((state) => {
-      state.categoryOpenStateByView[view][category] = status
+      state.categoryOpenStateByView[view]![category] = status
     })
   }
 
   expandCategoryOpenStateByView(view: FeedViewType, isOpen: boolean) {
     immerSet((state) => {
-      for (const category in state.categoryOpenStateByView[view]) {
-        state.categoryOpenStateByView[view][category] = isOpen
+      for (const category in state.categoryOpenStateByView[view]!) {
+        state.categoryOpenStateByView[view]![category] = isOpen
       }
     })
   }
@@ -234,15 +235,15 @@ class SubscriptionSyncService {
       immerSet((draft) => {
         if (
           subscription.category &&
-          !draft.categories[subscription.view].has(subscription.category)
+          !draft.categories[subscription.view]!.has(subscription.category)
         ) {
           addNewCategory = true
-          draft.categories[subscription.view].add(subscription.category)
+          draft.categories[subscription.view]!.add(subscription.category)
         }
 
         if (subscription.type === "feed") {
-          draft.feedIdByView[current.view].delete(current.feedId!)
-          draft.feedIdByView[subscription.view].add(subscription.feedId!)
+          draft.feedIdByView[current.view]!.delete(current.feedId!)
+          draft.feedIdByView[subscription.view]!.add(subscription.feedId!)
         }
 
         draft.data[subscriptionId] = subscription
@@ -251,12 +252,12 @@ class SubscriptionSyncService {
     tx.rollback((current) => {
       immerSet((draft) => {
         if (addNewCategory && subscription.category) {
-          draft.categories[subscription.view].delete(subscription.category)
+          draft.categories[subscription.view]!.delete(subscription.category)
         }
 
         if (subscription.type === "feed") {
-          draft.feedIdByView[subscription.view].delete(subscription.feedId!)
-          draft.feedIdByView[current.view].add(current.feedId!)
+          draft.feedIdByView[subscription.view]!.delete(subscription.feedId!)
+          draft.feedIdByView[current.view]!.add(current.feedId!)
         }
 
         draft.data[subscriptionId] = current
@@ -283,14 +284,14 @@ class SubscriptionSyncService {
     const data = await api().subscriptions.create(subscription)
 
     if (data.feed) {
-      feedActions.upsertMany([data.feed])
+      feedActions.upsertMany([data.feed as any])
       tracker.subscribe({ feedId: data.feed.id, view: subscription.view })
     }
 
     if (data.list) {
       listActions.upsertMany([
         {
-          ...data.list,
+          ...(data.list as any),
           userId: data.list.ownerUserId,
           type: "list",
           subscriptionCount: null,
@@ -343,16 +344,16 @@ class SubscriptionSyncService {
           if (!subscription) continue
           draft.subscriptionIdSet.delete(getSubscriptionDBId(subscription))
           if (subscription.feedId) {
-            draft.feedIdByView[subscription.view].delete(subscription.feedId)
-            draft.feedIdByView[FeedViewType.All].delete(subscription.feedId)
+            draft.feedIdByView[subscription.view]!.delete(subscription.feedId)
+            draft.feedIdByView[FeedViewType.All]!.delete(subscription.feedId)
           }
           if (subscription.listId) {
-            draft.listIdByView[subscription.view].delete(subscription.listId)
-            draft.listIdByView[FeedViewType.All].delete(subscription.listId)
+            draft.listIdByView[subscription.view]!.delete(subscription.listId)
+            draft.listIdByView[FeedViewType.All]!.delete(subscription.listId)
           }
           if (subscription.category) {
-            draft.categories[subscription.view].delete(subscription.category)
-            draft.categories[FeedViewType.All].delete(subscription.category)
+            draft.categories[subscription.view]!.delete(subscription.category)
+            draft.categories[FeedViewType.All]!.delete(subscription.category)
           }
           delete draft.data[id]
         }
@@ -377,16 +378,16 @@ class SubscriptionSyncService {
 
           draft.subscriptionIdSet.add(getSubscriptionDBId(subscription))
           if (subscription.feedId) {
-            draft.feedIdByView[subscription.view].add(subscription.feedId)
-            draft.feedIdByView[FeedViewType.All].add(subscription.feedId)
+            draft.feedIdByView[subscription.view]!.add(subscription.feedId)
+            draft.feedIdByView[FeedViewType.All]!.add(subscription.feedId)
           }
           if (subscription.listId) {
-            draft.listIdByView[subscription.view].add(subscription.listId)
-            draft.listIdByView[FeedViewType.All].add(subscription.listId)
+            draft.listIdByView[subscription.view]!.add(subscription.listId)
+            draft.listIdByView[FeedViewType.All]!.add(subscription.listId)
           }
           if (subscription.category) {
-            draft.categories[subscription.view].add(subscription.category)
-            draft.categories[FeedViewType.All].add(subscription.category)
+            draft.categories[subscription.view]!.add(subscription.category)
+            draft.categories[FeedViewType.All]!.add(subscription.category)
           }
         }
       })
@@ -436,12 +437,12 @@ class SubscriptionSyncService {
           if (!subscription) continue
 
           const currentView = subscription.view
-          draft.feedIdByView[currentView].delete(feedId)
-          draft.feedIdByView[newView].add(feedId)
+          draft.feedIdByView[currentView]!.delete(feedId)
+          draft.feedIdByView[newView]!.add(feedId)
           subscription.view = newView
 
           if (newCategory) {
-            draft.categories[newView].add(newCategory)
+            draft.categories[newView]!.add(newCategory)
             subscription.category = newCategory
           }
         }
@@ -464,8 +465,8 @@ class SubscriptionSyncService {
           if (!current[index]) continue
 
           subscription.view = current[index].view
-          draft.feedIdByView[newView].delete(feedId)
-          draft.feedIdByView[current[index].view].add(feedId)
+          draft.feedIdByView[newView]!.delete(feedId)
+          draft.feedIdByView[current[index]!.view]!.add(feedId)
 
           if (newCategory) {
             const currentCategory = current[index].category
@@ -504,9 +505,9 @@ class SubscriptionSyncService {
           return
         }
 
-        draft.data[listId].view = newView
-        draft.listIdByView[currentView].delete(listId)
-        draft.listIdByView[newView].add(listId)
+        draft.data[listId]!.view = newView
+        draft.listIdByView[currentView]!.delete(listId)
+        draft.listIdByView[newView]!.add(listId)
       })
     })
 
@@ -523,9 +524,9 @@ class SubscriptionSyncService {
           return
         }
 
-        draft.data[listId].view = current.view
-        draft.listIdByView[newView].delete(listId)
-        draft.listIdByView[currentView].add(listId)
+        draft.data[listId]!.view = current.view
+        draft.listIdByView[newView]!.delete(listId)
+        draft.listIdByView[currentView]!.add(listId)
       })
     })
 
@@ -552,7 +553,7 @@ class SubscriptionSyncService {
           if (!subscription) continue
           subscription.category = null
         }
-        draft.categories[view].delete(category)
+        draft.categories[view]!.delete(category)
       })
     })
 
@@ -571,7 +572,7 @@ class SubscriptionSyncService {
           subscription.category = category
         }
 
-        draft.categories[view].add(category)
+        draft.categories[view]!.add(category)
       })
     })
 
@@ -625,13 +626,13 @@ class SubscriptionSyncService {
           if (!subscription) continue
           subscription.category = newCategory
         }
-        draft.categories[view].add(newCategory)
-        draft.categories[view].delete(lastCategory)
+        draft.categories[view]!.add(newCategory)
+        draft.categories[view]!.delete(lastCategory)
 
-        const lastCategoryOpenState = draft.categoryOpenStateByView[view][lastCategory]
+        const lastCategoryOpenState = draft.categoryOpenStateByView[view]![lastCategory]
         if (typeof lastCategoryOpenState === "boolean") {
-          draft.categoryOpenStateByView[view][newCategory] = lastCategoryOpenState
-          delete draft.categoryOpenStateByView[view][lastCategory]
+          draft.categoryOpenStateByView[view]![newCategory] = lastCategoryOpenState
+          delete draft.categoryOpenStateByView[view]![lastCategory]
         }
       })
     })
@@ -651,13 +652,13 @@ class SubscriptionSyncService {
           const defaultCategory = getDefaultCategory(subscription)
           subscription.category = lastCategory !== defaultCategory ? lastCategory : null
         }
-        draft.categories[view].delete(newCategory)
-        draft.categories[view].add(lastCategory)
+        draft.categories[view]!.delete(newCategory)
+        draft.categories[view]!.add(lastCategory)
 
-        const lastCategoryOpenState = draft.categoryOpenStateByView[view][newCategory]
+        const lastCategoryOpenState = draft.categoryOpenStateByView[view]![newCategory]
         if (typeof lastCategoryOpenState === "boolean") {
-          draft.categoryOpenStateByView[view][lastCategory] = lastCategoryOpenState
-          delete draft.categoryOpenStateByView[view][newCategory]
+          draft.categoryOpenStateByView[view]![lastCategory] = lastCategoryOpenState
+          delete draft.categoryOpenStateByView[view]![newCategory]
         }
       })
     })

--- a/packages/internal/store/src/modules/translation/hooks.ts
+++ b/packages/internal/store/src/modules/translation/hooks.ts
@@ -87,7 +87,7 @@ export const useEntryTranslation = ({
     useCallback(
       (state) => {
         if (!enabled && !actionSetting) return
-        return state.data[entryId]?.[language]
+        return state.data[entryId]?.[language as SupportedActionLanguage]
       },
       [actionSetting, entryId, language, enabled],
     ),

--- a/packages/internal/store/src/modules/user/store.ts
+++ b/packages/internal/store/src/modules/user/store.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "@follow/constants"
+import type { UserRole } from "@follow/constants"
 import type { UserSchema } from "@follow/database/schemas/types"
 import { UserService } from "@follow/database/services/user"
 import type { AuthUser } from "@follow-app/client-sdk"
@@ -51,10 +51,10 @@ class UserSyncService {
         immerSet((state) => {
           for (const user of usersArray) {
             state.users[user.id] = {
+              ...user,
               email: null,
               isMe: whoami?.id === user.id,
-              ...user,
-            }
+            } as UserModel
           }
         })
         return usersObject
@@ -97,7 +97,7 @@ class UserSyncService {
       state.rsshubSubscriptionLimit = res.rsshubSubscriptionLimit ?? null
       state.feedSubscriptionLimit = res.feedSubscriptionLimit ?? null
     })
-    userActions.upsertMany([user])
+    userActions.upsertMany([user as unknown as UserModel])
 
     return res
   }
@@ -127,7 +127,7 @@ class UserSyncService {
         ...whoami,
         ...data,
       }
-      userActions.upsertMany([nextUser])
+      userActions.upsertMany([nextUser as unknown as UserModel])
     })
     tx.rollback(() => {
       immerSet((state) => {
@@ -189,20 +189,9 @@ class UserSyncService {
     tx.persist(async () => {
       const { whoami } = get()
       if (!whoami) return
-      userActions.upsertMany([{ ...whoami, email }])
+      userActions.upsertMany([{ ...whoami, email } as unknown as UserModel])
     })
     await tx.run()
-  }
-
-  async applyInvitationCode(code: string) {
-    const res = await api().invitations.use({ code })
-    if (res.code === 0) {
-      immerSet((state) => {
-        state.role = UserRole.Pro
-      })
-    }
-
-    return res
   }
 
   async fetchUser(userId: string | undefined) {

--- a/packages/internal/store/src/morph/api.ts
+++ b/packages/internal/store/src/morph/api.ts
@@ -221,7 +221,7 @@ class APIMorph {
         feedId: item.feeds.id,
         inboxHandle: item.feeds.type === "inbox" ? item.feeds.id : null,
         read: item.read,
-        sources: "from" in item ? (item.from ?? null) : null,
+        sources: "from" in item && Array.isArray(item.from) ? item.from : null,
         settings: item.settings ?? null,
       })
     }

--- a/packages/internal/tracker/src/tracker-points.ts
+++ b/packages/internal/tracker/src/tracker-points.ts
@@ -6,7 +6,13 @@ import { trackManager } from "./track-manager"
 export class TrackerPoints {
   // App
   identify(props: AuthUser) {
-    this.manager.identify(props)
+    this.manager.identify({
+      id: props.id,
+      name: props.name,
+      email: props.email,
+      image: props.image,
+      handle: props.handle,
+    })
     this.track(TrackerMapper.Identify, {
       id: props.id,
       name: props.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@follow-app/client-sdk':
-      specifier: 0.3.92
-      version: 0.3.92
     '@folo-services/ai-tools':
-      specifier: 0.2.65
-      version: 0.2.65
+      specifier: 0.2.66
+      version: 0.2.66
     tailwindcss-uikit-colors:
       specifier: 1.0.0
       version: 1.0.0
@@ -25,6 +22,8 @@ overrides:
   '@floating-ui/dom': 1.7.2
   '@floating-ui/react': 0.27.14
   '@floating-ui/react-dom': 2.1.4
+  '@follow-app/client-sdk': 0.3.95
+  '@folo-services/drizzle': 0.1.47
   '@react-native-menu/menu': 2.0.0
   '@types/react': 19.1.17
   array-includes: npm:@nolyfill/array-includes@latest
@@ -188,8 +187,8 @@ importers:
   apps/cli:
     dependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       commander:
         specifier: 14.0.1
         version: 14.0.1
@@ -298,7 +297,7 @@ importers:
         version: 7.1.2(postcss@8.5.6)
       drizzle-orm:
         specifier: 0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
       electron:
         specifier: 38.3.0
         version: 38.3.0
@@ -381,8 +380,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow-app/readability':
         specifier: workspace:*
         version: link:../../../../packages/readability
@@ -490,8 +489,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2(electron@38.3.0)
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/database':
         specifier: workspace:*
         version: link:../../../../packages/internal/database
@@ -810,7 +809,7 @@ importers:
         version: link:../../../../packages/internal/utils
       '@folo-services/ai-tools':
         specifier: 'catalog:'
-        version: 0.2.65(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.16.3)
+        version: 0.2.66(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.18.0)
       '@types/node':
         specifier: 25.2.3
         version: 25.2.3
@@ -1063,7 +1062,7 @@ importers:
     dependencies:
       '@better-auth/expo':
         specifier: 1.5.5
-        version: 1.5.5(b83b30101b819d6c970e7e563b1dcee9)
+        version: 1.5.5(67e20e7256896c56575937885b5cceef)
       '@expo/metro-runtime':
         specifier: 6.1.2
         version: 6.1.2(expo@54.0.33)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0)
@@ -1071,8 +1070,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1(@types/react@19.1.17)(react@19.1.0)
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/components':
         specifier: workspace:*
         version: link:../../packages/internal/components
@@ -1150,7 +1149,7 @@ importers:
         version: 1.5.6
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       camelcase-keys:
         specifier: 10.0.2
         version: 10.0.2
@@ -1452,8 +1451,8 @@ importers:
         specifier: 6.2.1
         version: 6.2.1
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/tracker':
         specifier: workspace:*
         version: link:../../packages/internal/tracker
@@ -1956,8 +1955,8 @@ importers:
   packages/internal/constants:
     dependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/configs':
         specifier: workspace:*
         version: link:../../configs
@@ -1968,8 +1967,8 @@ importers:
   packages/internal/database:
     dependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/constants':
         specifier: workspace:*
         version: link:../constants
@@ -1984,13 +1983,13 @@ importers:
         version: 6.0.85(zod@4.3.6)
       drizzle-orm:
         specifier: 0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
       expo-sqlite:
         specifier: 16.0.10
         version: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0)
       sqlocal:
         specifier: npm:@hyoban/sqlocal@0.14.1-fork.4
-        version: '@hyoban/sqlocal@0.14.1-fork.4(bufferutil@4.1.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(kysely@0.28.12)'
+        version: '@hyoban/sqlocal@0.14.1-fork.4(bufferutil@4.1.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(kysely@0.28.12)'
       wa-sqlite:
         specifier: git+https://github.com/rhashimoto/wa-sqlite.git#v1.0.8
         version: https://codeload.github.com/rhashimoto/wa-sqlite/tar.gz/03c00ed67cd934bd664ae310234bba317928f851
@@ -2040,8 +2039,8 @@ importers:
   packages/internal/models:
     dependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/constants':
         specifier: workspace:*
         version: link:../constants
@@ -2063,7 +2062,7 @@ importers:
     dependencies:
       '@better-auth/stripe':
         specifier: 1.5.5
-        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@3.25.76))(stripe@20.3.1(@types/node@25.2.3))
+        version: 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@3.25.76))(stripe@20.3.1(@types/node@25.2.3))
       '@electron-toolkit/preload':
         specifier: 3.0.2
         version: 3.0.2(electron@38.3.0)
@@ -2071,11 +2070,11 @@ importers:
         specifier: 2.0.0
         version: 2.0.0(@types/node@25.2.3)
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@folo-services/drizzle':
-        specifier: 0.1.44
-        version: 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
+        specifier: 0.1.47
+        version: 0.1.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
       '@t3-oss/env-core':
         specifier: 0.13.10
         version: 0.13.10(typescript@5.9.3)(zod@3.25.76)
@@ -2084,10 +2083,10 @@ importers:
         version: 6.0.85(zod@3.25.76)
       better-auth:
         specifier: 1.5.5
-        version: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       drizzle-orm:
         specifier: 0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
       sonner:
         specifier: 2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2101,8 +2100,8 @@ importers:
   packages/internal/store:
     dependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/configs':
         specifier: workspace:*
         version: link:../../configs
@@ -2150,8 +2149,8 @@ importers:
         version: 4.34.0(expo-application@7.0.8(expo@54.0.33))(expo-device@8.0.10(expo@54.0.33))(expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)))(expo-localization@17.0.8(expo@54.0.33)(react@19.1.0))(react-native-device-info@15.0.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0)))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))
     devDependencies:
       '@follow-app/client-sdk':
-        specifier: 'catalog:'
-        version: 0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.3.95
+        version: 0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@follow/configs':
         specifier: workspace:*
         version: link:../../configs
@@ -2254,32 +2253,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@2.0.7':
-    resolution: {integrity: sha512-/AI5AKi4vOK9SEb8Z1dfXkhsJ5NAfWsoJQc96B/mzn2KIrjw5occOjIwD06scuhV9xWlghCoXJT1sQD9QH/tyg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/gateway@3.0.45':
     resolution: {integrity: sha512-ZB6kHV+D8mLCRnkpWotLCV/rZK4NiODxx4Kv7JdT9QmQknbG/scbE4iyoT4JLFdULA8Y/IVbMvyE0Nwq3Dceqw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@2.0.63':
-    resolution: {integrity: sha512-J7XJaTOvorCDWxfEmDOPahRyXkt4207OCPp/JcjWYAux/8FCh2xUgjQivrcM4AxHQWYCSOWChGtCw7F5mNmLkA==}
+  '@ai-sdk/openai@3.0.28':
+    resolution: {integrity: sha512-m2Dm6fwUzMksqnPrd5f/WZ4cZ9GTZHpzsVO6jxKQwwc84gFHzAFZmUCG0C5mV7XlPOw4mwaiYV3HfLiEfphvvA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@3.0.12':
     resolution: {integrity: sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@3.0.16':
-    resolution: {integrity: sha512-lsWQY9aDXHitw7C1QRYIbVGmgwyT98TF3MfM8alNIXKpdJdi+W782Rzd9f1RyOfgRmZ08gJ2EYNDhWNK7RqpEA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2317,8 +2304,8 @@ packages:
     peerDependencies:
       ajv: '>=8'
 
-  '@asteasolutions/zod-to-openapi@8.4.1':
-    resolution: {integrity: sha512-WmJUsFINbnWxGvHSd16aOjgKf+5GsfdxruO2YDLcgplsidakCauik1lhlk83YDH06265Yd1XtUyF24o09uygpw==}
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
       zod: ^4.0.0
 
@@ -3082,17 +3069,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@better-auth/core@1.3.28':
-    resolution: {integrity: sha512-iZOGKlXaNEIEj0Q3z7+REE94I89YUJ0sel/1pvm1qqdHkm59G+ToTysHtyTcLYby3+UtAeJRKyFAY0nwJH0H7A==}
-    peerDependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
-      better-call: 1.0.19
-      better-sqlite3: ^12.4.1
-      jose: ^6.1.0
-      kysely: ^0.28.5
-      nanostores: ^1.0.1
-
   '@better-auth/core@1.5.5':
     resolution: {integrity: sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==}
     peerDependencies:
@@ -3177,22 +3153,13 @@ packages:
       better-call: 1.3.2
       stripe: ^18 || ^19 || ^20
 
-  '@better-auth/telemetry@1.3.28':
-    resolution: {integrity: sha512-qZtV82IFuyQZc2c37VkiDgO/qfqPnJuWIyeC/iFK1AA5N8RSuC2+CVIH1sNDytPXUAthbYeOzcOCW2YEkgz1Ow==}
-
   '@better-auth/telemetry@1.5.5':
     resolution: {integrity: sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ==}
     peerDependencies:
       '@better-auth/core': 1.5.5
 
-  '@better-auth/utils@0.3.0':
-    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
-
   '@better-auth/utils@0.3.1':
     resolution: {integrity: sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==}
-
-  '@better-fetch/fetch@1.1.18':
-    resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -4972,23 +4939,23 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@follow-app/client-sdk@0.3.92':
-    resolution: {integrity: sha512-lJNMXyt40vkGFSsLt83zCE/zDjh2numbgR4FgR5Qh8VCp5cExmy+LgYOgmi+q3N8jpWyHw/ipE3cX1k3SPP/mQ==}
+  '@follow-app/client-sdk@0.3.95':
+    resolution: {integrity: sha512-hQmj+pnHsKwkeXdQzPVSYIcGIDWAQyw7hgwvYljQyEw3iWfHfs4Ex5JWtM2R2TYGINyoLOfYJQggNNWbjtytvQ==}
 
-  '@folo-services/ai-tools@0.2.65':
-    resolution: {integrity: sha512-Z6sScc3Hl66Yr8vHRy/yzOoFPhqqhQi0M9xjlmXd+d+0U1PCCKLwNSF+5ORjFDt2PICyA8thE8HBwI/Rl9pWUg==}
+  '@folo-services/ai-tools@0.2.66':
+    resolution: {integrity: sha512-OZrmFlbeHoo2Jp/+FTHTvaSs0GBW6QPF6CXUg7cVQs0VQFFhhIZh9beAW356paNrJhfj6rFTLICX5Xop+g4aQA==}
 
-  '@folo-services/constants@0.1.53':
-    resolution: {integrity: sha512-zD6CCC8+Sjos7tdutH+cefv5K+s+7jhYSM/asKUBGDq0FgmpgHnl9apB5qldlH/6hHtFwf+9HxjBtcHcewsNzg==}
+  '@folo-services/constants@0.1.55':
+    resolution: {integrity: sha512-qiWk3n2LzGi/SvtjYr+CnUhQgEGFQGe97dO8s7CUAJ+TV7BM9TSWvg/RauIVHjw0zydiM8anrfj/r01COgM4rg==}
 
-  '@folo-services/drizzle@0.1.44':
-    resolution: {integrity: sha512-PycJ55HX/dg3I7n6gIbI9d/mxxHuOVLMyvNowNDWcvTZ3bo6v+XKEk5StSJslBzAVFjHVa0kaKY0UAHz0hSmsg==}
+  '@folo-services/drizzle@0.1.47':
+    resolution: {integrity: sha512-vE8ivPVjiCmbhi13FII5GD+uURK3T3Vm9QP3HyWkMA8K0u3We1jnppviR0FZw+L+bhEWWlcEYJTTVWQTlajvbw==}
 
-  '@folo-services/exceptions@0.1.28':
-    resolution: {integrity: sha512-Et37e8rtJ6k5mJUJ95Q1cC+p5qrL5RxDJsyN2WtImPD1KACy/uYG0xbhMocmA6E91EL6+iLMy4x0QDI/e2OcQA==}
+  '@folo-services/exceptions@0.1.30':
+    resolution: {integrity: sha512-qbWqvl39yYy4oX5ERG9TydNv8wt7653W0bBP0/Iy708hTu+tXdneSoCn/eqrqe3C0DPAcPWKScG5Y3K2DAfNEA==}
 
-  '@folo-services/shared@0.0.44':
-    resolution: {integrity: sha512-/yQB3ZE1Kw8M7d+MjzJTY/TBciroT8LFXVG5boyf7KXyT+H3bPtu6DBsE2R+0qZj82XwM2fj2DkyWA4//3aw8w==}
+  '@folo-services/shared@0.0.47':
+    resolution: {integrity: sha512-nLGUbDWOOUQ2bQo/VTDwvUbvRnehwJwVuqCqW6Pqip3771Wom/RD+F97Tboa7LKWyEMs50494l29EpM4NgMmRg==}
 
   '@fontsource/sn-pro@5.2.6':
     resolution: {integrity: sha512-oBhp9tiPQdIoHqnREbbbIq7WzT9ZZZAIwBGMmT7RQ0Kb9AfIhjj4DE6Cdd1WI71QhBx1hhVR2g9fGZPWpYVP+g==}
@@ -5045,11 +5012,8 @@ packages:
       react: 19.1.0
       react-dom: 19.1.0
 
-  '@hexagon/base64@1.1.28':
-    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
-
-  '@hono/zod-openapi@1.1.4':
-    resolution: {integrity: sha512-4BbOtd6oKg20yo6HLluVbEycBLLIfdKX5o/gUSoKZ2uBmeP4Og/VDfIX3k9pbNEX5W3fRkuPeVjGA+zaQDVY1A==}
+  '@hono/zod-openapi@1.2.1':
+    resolution: {integrity: sha512-aZza4V8wkqpdHBWFNPiCeWd0cGOXbYuQW9AyezHs/jwQm5p67GkUyXwfthAooAwnG7thTpvOJkThZpCoY6us8w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       hono: '>=4.3.6'
@@ -5575,9 +5539,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@levischuck/tiny-cbor@0.2.11':
-    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
-
   '@lexical/clipboard@0.40.0':
     resolution: {integrity: sha512-FWyAKwbGbmwLbG6biyxB/MQkELzcbd6E89Xufarbx/1VZ2pX/BMaeVD4J7ojHgIZ4omTNI6nKH26K4wWySCIGQ==}
 
@@ -5902,43 +5863,6 @@ packages:
 
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
-
-  '@peculiar/asn1-android@2.6.0':
-    resolution: {integrity: sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==}
-
-  '@peculiar/asn1-cms@2.6.1':
-    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
-
-  '@peculiar/asn1-csr@2.6.1':
-    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
-
-  '@peculiar/asn1-ecc@2.6.1':
-    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
-
-  '@peculiar/asn1-pfx@2.6.1':
-    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
-
-  '@peculiar/asn1-pkcs8@2.6.1':
-    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
-
-  '@peculiar/asn1-pkcs9@2.6.1':
-    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
-
-  '@peculiar/asn1-rsa@2.6.1':
-    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
-
-  '@peculiar/asn1-schema@2.6.0':
-    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
-
-  '@peculiar/asn1-x509-attr@2.6.1':
-    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
-
-  '@peculiar/asn1-x509@2.6.1':
-    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
-
-  '@peculiar/x509@1.14.3':
-    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
-    engines: {node: '>=20.0.0'}
 
   '@pengx17/electron-forge-maker-appimage@1.2.1':
     resolution: {integrity: sha512-6w1XbUUZS431UaubbBQvKYDGs2MnTFxEWeJX1RjQXrxl0LrZULOarTogpda8UR9y7nAwtuEKm84OxWBrtH87ww==}
@@ -7435,13 +7359,6 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@simplewebauthn/browser@13.2.2':
-    resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
-
-  '@simplewebauthn/server@13.2.2':
-    resolution: {integrity: sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==}
-    engines: {node: '>=20.0.0'}
-
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -8202,10 +8119,6 @@ packages:
     resolution: {integrity: sha512-JekxQ0RApo4gS4un/iMGsIL1/k4KUBe3HmnGcDvzHuFBdQdudEJgTqcsJC7y6Ul4Yw5CeykgvQbX2XeEJd0+DA==}
     engines: {node: '>= 20'}
 
-  '@vercel/oidc@3.0.3':
-    resolution: {integrity: sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==}
-    engines: {node: '>= 20'}
-
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -8388,11 +8301,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8483,12 +8397,6 @@ packages:
 
   ai@5.0.68:
     resolution: {integrity: sha512-SB6r+4TkKVlSg2ozGBSfuf6Is5hrcX/bpGBzOoyHIN3b4ILGhaly0IHEvP8+3GGIHXqtkPVEUmR6V05jKdjNlg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@5.0.88:
-    resolution: {integrity: sha512-72nSwQT6iMgfbblwDo59cmFTtsNzfyMVH9MigeIh5IHiqoDqxRAkv0IBb9XYj6RD52tAJw7Wj/n+LEhezvYqkw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8676,10 +8584,6 @@ packages:
 
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
-  asn1js@3.0.7:
-    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
-    engines: {node: '>=12.0.0'}
 
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
@@ -8931,35 +8835,6 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
-  better-auth@1.3.28:
-    resolution: {integrity: sha512-fSaeRsTSkzCSSKREFsm7z7TsTMC8ghGrwCN+mumxCZiyc8Fh/UThUwURlTJmsR0YVB0DMR8ejQH+c38WhdQslQ==}
-    peerDependencies:
-      '@lynx-js/react': '*'
-      '@sveltejs/kit': '*'
-      next: '*'
-      react: '*'
-      react-dom: '*'
-      solid-js: '*'
-      svelte: '*'
-      vue: '*'
-    peerDependenciesMeta:
-      '@lynx-js/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      solid-js:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-
   better-auth@1.5.5:
     resolution: {integrity: sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==}
     peerDependencies:
@@ -9021,9 +8896,6 @@ packages:
         optional: true
       vue:
         optional: true
-
-  better-call@1.0.19:
-    resolution: {integrity: sha512-sI3GcA1SCVa3H+CDHl8W8qzhlrckwXOTKhqq3OOPXjgn5aTOMIqGY34zLY/pHA6tRRMjTUC3lz5Mi7EbDA24Kw==}
 
   better-call@1.3.2:
     resolution: {integrity: sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==}
@@ -12472,9 +12344,6 @@ packages:
       jotai: ^2.0.0
       react: 19.1.0
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
-
   jose@6.2.1:
     resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
@@ -12676,10 +12545,6 @@ packages:
   ky@1.14.3:
     resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
     engines: {node: '>=18'}
-
-  kysely@0.28.11:
-    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
-    engines: {node: '>=20.0.0'}
 
   kysely@0.28.12:
     resolution: {integrity: sha512-kWiueDWXhbCchgiotwXkwdxZE/6h56IHAeFWg4euUfW0YsmO9sxbAxzx1KLLv2lox15EfuuxHQvgJ1qIfZuHGw==}
@@ -13699,10 +13564,6 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
-  nanostores@1.1.0:
-    resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
-    engines: {node: ^20.0.0 || >=22.0.0}
-
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -14286,8 +14147,8 @@ packages:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
-  pg@8.16.3:
-    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+  pg@8.18.0:
+    resolution: {integrity: sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -14983,13 +14844,6 @@ packages:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
 
-  pvtsutils@1.3.6:
-    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
-
-  pvutils@1.1.5:
-    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
-    engines: {node: '>=16.0.0'}
-
   qr.js@0.0.0:
     resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
 
@@ -15569,9 +15423,6 @@ packages:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  reflect-metadata@0.2.2:
-    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
-
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
     engines: {node: '>=4'}
@@ -15843,9 +15694,6 @@ packages:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-
-  rou3@0.5.1:
-    resolution: {integrity: sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==}
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
@@ -16895,10 +16743,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  tsyringe@4.10.0:
-    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
-    engines: {node: '>= 6.0.0'}
-
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -17023,9 +16867,6 @@ packages:
 
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
-
-  uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -17903,9 +17744,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -17965,13 +17803,6 @@ snapshots:
       '@vercel/oidc': 3.0.2
       zod: 4.3.6
 
-  '@ai-sdk/gateway@2.0.7(zod@4.1.12)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.16(zod@4.1.12)
-      '@vercel/oidc': 3.0.3
-      zod: 4.1.12
-
   '@ai-sdk/gateway@3.0.45(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -17986,11 +17817,11 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/openai@2.0.63(zod@4.1.12)':
+  '@ai-sdk/openai@3.0.28(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.16(zod@4.1.12)
-      zod: 4.1.12
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
+      zod: 4.3.6
 
   '@ai-sdk/provider-utils@3.0.12(zod@4.3.6)':
     dependencies:
@@ -17998,13 +17829,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
-
-  '@ai-sdk/provider-utils@3.0.16(zod@4.1.12)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.1.12
 
   '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
     dependencies:
@@ -18046,10 +17870,10 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  '@asteasolutions/zod-to-openapi@8.4.1(zod@4.1.12)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 4.1.12
+      zod: 4.3.6
 
   '@babel/code-frame@7.10.4':
     dependencies:
@@ -19001,17 +18825,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
-  '@better-auth/core@1.3.28(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(better-sqlite3@12.6.2)(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
-    dependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
-      better-call: 1.0.19
-      better-sqlite3: 12.6.2
-      jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.0
-      zod: 4.3.6
-
   '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
@@ -19023,18 +18836,29 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))':
+  '@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.2(zod@4.3.6)
+      jose: 6.2.1
+      kysely: 0.28.12
+      nanostores: 1.2.0
+      zod: 4.3.6
+
+  '@better-auth/drizzle-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
 
-  '@better-auth/expo@1.5.5(b83b30101b819d6c970e7e563b1dcee9)':
+  '@better-auth/expo@1.5.5(67e20e7256896c56575937885b5cceef)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.3.2(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -19042,60 +18866,44 @@ snapshots:
       expo-linking: 8.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0)
       expo-web-browser: 15.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))
 
-  '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)':
+  '@better-auth/kysely-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       kysely: 0.28.12
 
-  '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))':
+  '@better-auth/mongo-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       mongodb: 7.1.0(socks@2.8.7)
 
-  '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/prisma-adapter@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/stripe@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@3.25.76))(stripe@20.3.1(@types/node@25.2.3))':
+  '@better-auth/stripe@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.3.2(zod@3.25.76))(stripe@20.3.1(@types/node@25.2.3))':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
-      better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.3.2(zod@3.25.76)
       defu: 6.1.4
       stripe: 20.3.1(@types/node@25.2.3)
       zod: 4.3.6
 
-  '@better-auth/telemetry@1.3.28(better-call@1.0.19)(better-sqlite3@12.6.2)(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
-    dependencies:
-      '@better-auth/core': 1.3.28(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(better-sqlite3@12.6.2)(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
-    transitivePeerDependencies:
-      - better-call
-      - better-sqlite3
-      - jose
-      - kysely
-      - nanostores
-
-  '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))':
+  '@better-auth/telemetry@1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))':
     dependencies:
       '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.0': {}
-
   '@better-auth/utils@0.3.1': {}
-
-  '@better-fetch/fetch@1.1.18': {}
 
   '@better-fetch/fetch@1.1.21': {}
 
@@ -21639,14 +21447,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@follow-app/client-sdk@0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@follow-app/client-sdk@0.3.95(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@folo-services/constants': 0.1.53
-      '@folo-services/drizzle': 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)
-      '@folo-services/exceptions': 0.1.28
-      '@folo-services/shared': 0.0.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)(pg@8.16.3)
-      better-auth: 1.3.28(better-sqlite3@12.6.2)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      zod: 4.1.12
+      '@folo-services/constants': 0.1.55
+      '@folo-services/drizzle': 0.1.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
+      '@folo-services/exceptions': 0.1.30
+      '@folo-services/shared': 0.0.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.18.0)
+      better-auth: 1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -21660,6 +21468,8 @@ snapshots:
       - '@planetscale/database'
       - '@prisma/client'
       - '@sveltejs/kit'
+      - '@tanstack/react-start'
+      - '@tanstack/solid-start'
       - '@tidbcloud/serverless'
       - '@types/better-sqlite3'
       - '@types/pg'
@@ -21669,11 +21479,14 @@ snapshots:
       - '@xata.io/client'
       - better-sqlite3
       - bun-types
+      - drizzle-kit
+      - drizzle-orm
       - expo-sqlite
       - gel
       - hono
       - knex
       - kysely
+      - mongodb
       - mysql2
       - next
       - pg
@@ -21686,64 +21499,16 @@ snapshots:
       - sql.js
       - sqlite3
       - svelte
+      - vitest
       - vue
 
-  '@follow-app/client-sdk@0.3.92(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@folo-services/ai-tools@0.2.66(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.18.0)':
     dependencies:
-      '@folo-services/constants': 0.1.53
-      '@folo-services/drizzle': 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
-      '@folo-services/exceptions': 0.1.28
-      '@folo-services/shared': 0.0.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.16.3)
-      better-auth: 1.3.28(better-sqlite3@12.6.2)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@lynx-js/react'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@sveltejs/kit'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - gel
-      - hono
-      - knex
-      - kysely
-      - mysql2
-      - next
-      - pg
-      - pg-native
-      - postgres
-      - prisma
-      - react
-      - react-dom
-      - solid-js
-      - sql.js
-      - sqlite3
-      - svelte
-      - vue
-
-  '@folo-services/ai-tools@0.2.65(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.16.3)':
-    dependencies:
-      '@ai-sdk/openai': 2.0.63(zod@4.1.12)
-      '@folo-services/drizzle': 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
-      ai: 5.0.88(zod@4.1.12)
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
-      zod: 4.1.12
+      '@ai-sdk/openai': 3.0.28(zod@4.3.6)
+      '@folo-services/drizzle': 0.1.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
+      ai: 6.0.85(zod@4.3.6)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -21777,19 +21542,19 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@folo-services/constants@0.1.53':
+  '@folo-services/constants@0.1.55':
     dependencies:
-      zod: 4.1.12
+      zod: 4.3.6
 
-  '@folo-services/drizzle@0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)':
+  '@folo-services/drizzle@0.1.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)':
     dependencies:
-      '@folo-services/exceptions': 0.1.28
-      '@hono/zod-openapi': 1.1.4(hono@4.12.1)(zod@4.1.12)
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3)
-      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3))(zod@4.1.12)
+      '@folo-services/exceptions': 0.1.30
+      '@hono/zod-openapi': 1.2.1(hono@4.12.1)(zod@4.3.6)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
+      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(zod@4.3.6)
       nanoid: 5.1.6
-      pg: 8.16.3
-      zod: 4.1.12
+      pg: 8.18.0
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -21822,98 +21587,16 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@folo-services/drizzle@0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)':
-    dependencies:
-      '@folo-services/exceptions': 0.1.28
-      '@hono/zod-openapi': 1.1.4(hono@4.12.1)(zod@4.1.12)
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
-      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(zod@4.1.12)
-      nanoid: 5.1.6
-      pg: 8.16.3
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - gel
-      - hono
-      - knex
-      - kysely
-      - mysql2
-      - pg-native
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
+  '@folo-services/exceptions@0.1.30': {}
 
-  '@folo-services/exceptions@0.1.28': {}
-
-  '@folo-services/shared@0.0.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)(pg@8.16.3)':
+  '@folo-services/shared@0.0.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.18.0)':
     dependencies:
-      '@folo-services/constants': 0.1.53
-      '@folo-services/drizzle': 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.11)
-      '@hono/zod-openapi': 1.1.4(hono@4.12.1)(zod@4.1.12)
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3)
-      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3))(zod@4.1.12)
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@cloudflare/workers-types'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - better-sqlite3
-      - bun-types
-      - expo-sqlite
-      - gel
-      - hono
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - pg-native
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-
-  '@folo-services/shared@0.0.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)(pg@8.16.3)':
-    dependencies:
-      '@folo-services/constants': 0.1.53
-      '@folo-services/drizzle': 0.1.44(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
-      '@hono/zod-openapi': 1.1.4(hono@4.12.1)(zod@4.1.12)
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
-      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(zod@4.1.12)
-      zod: 4.1.12
+      '@folo-services/constants': 0.1.55
+      '@folo-services/drizzle': 0.1.47(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(hono@4.12.1)(kysely@0.28.12)
+      '@hono/zod-openapi': 1.2.1(hono@4.12.1)(zod@4.3.6)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
+      drizzle-zod: 0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(zod@4.3.6)
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -22018,20 +21701,18 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.6.0(react@19.1.0)
 
-  '@hexagon/base64@1.1.28': {}
-
-  '@hono/zod-openapi@1.1.4(hono@4.12.1)(zod@4.1.12)':
+  '@hono/zod-openapi@1.2.1(hono@4.12.1)(zod@4.3.6)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 8.4.1(zod@4.1.12)
-      '@hono/zod-validator': 0.7.6(hono@4.12.1)(zod@4.1.12)
+      '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.12.1)(zod@4.3.6)
       hono: 4.12.1
       openapi3-ts: 4.5.0
-      zod: 4.1.12
+      zod: 4.3.6
 
-  '@hono/zod-validator@0.7.6(hono@4.12.1)(zod@4.1.12)':
+  '@hono/zod-validator@0.7.6(hono@4.12.1)(zod@4.3.6)':
     dependencies:
       hono: 4.12.1
-      zod: 4.1.12
+      zod: 4.3.6
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.1.0))':
     dependencies:
@@ -22051,12 +21732,12 @@ snapshots:
 
   '@hutson/parse-repository-url@5.0.0': {}
 
-  '@hyoban/sqlocal@0.14.1-fork.4(bufferutil@4.1.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(kysely@0.28.12)':
+  '@hyoban/sqlocal@0.14.1-fork.4(bufferutil@4.1.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(kysely@0.28.12)':
     dependencies:
       '@sqlite.org/sqlite-wasm': 3.50.0-build1
       coincident: 1.2.3(bufferutil@4.1.0)
     optionalDependencies:
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
       kysely: 0.28.12
     transitivePeerDependencies:
       - bufferutil
@@ -22629,8 +22310,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@levischuck/tiny-cbor@0.2.11': {}
-
   '@lexical/clipboard@0.40.0':
     dependencies:
       '@lexical/html': 0.40.0
@@ -23108,102 +22787,6 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.112.0': {}
-
-  '@peculiar/asn1-android@2.6.0':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-cms@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-csr@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-ecc@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-pfx@2.6.1':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-pkcs8@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-pkcs9@2.6.1':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pfx': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-rsa@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-schema@2.6.0':
-    dependencies:
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/asn1-x509-attr@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-x509@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/x509@1.14.3':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-csr': 2.6.1
-      '@peculiar/asn1-ecc': 2.6.1
-      '@peculiar/asn1-pkcs9': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      pvtsutils: 1.3.6
-      reflect-metadata: 0.2.2
-      tslib: 2.8.1
-      tsyringe: 4.10.0
 
   '@pengx17/electron-forge-maker-appimage@1.2.1(patch_hash=5b5ab1ba36e8c0d7ffee912ebf29c1a18bc101c9c661ceb1bb0bda3deaf4c667)(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)':
     dependencies:
@@ -24699,19 +24282,6 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@simplewebauthn/browser@13.2.2': {}
-
-  '@simplewebauthn/server@13.2.2':
-    dependencies:
-      '@hexagon/base64': 1.1.28
-      '@levischuck/tiny-cbor': 0.2.11
-      '@peculiar/asn1-android': 2.6.0
-      '@peculiar/asn1-ecc': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/x509': 1.14.3
-
   '@sinclair/typebox@0.27.10': {}
 
   '@sindresorhus/is@4.6.0': {}
@@ -25641,8 +25211,6 @@ snapshots:
 
   '@vercel/oidc@3.0.2': {}
 
-  '@vercel/oidc@3.0.3': {}
-
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/python-analysis@0.4.1':
@@ -26044,14 +25612,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
-  ai@5.0.88(zod@4.1.12):
-    dependencies:
-      '@ai-sdk/gateway': 2.0.7(zod@4.1.12)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.16(zod@4.1.12)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.1.12
-
   ai@6.0.85(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 3.0.45(zod@3.25.76)
@@ -26294,12 +25854,6 @@ snapshots:
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
-
-  asn1js@3.0.7:
-    dependencies:
-      pvtsutils: 1.3.6
-      pvutils: 1.1.5
-      tslib: 2.8.1
 
   assert-plus@1.0.0:
     optional: true
@@ -26587,38 +26141,15 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
-  better-auth@1.3.28(better-sqlite3@12.6.2)(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.18.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@better-auth/core': 1.3.28(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(better-sqlite3@12.6.2)(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/telemetry': 1.3.28(better-call@1.0.19)(better-sqlite3@12.6.2)(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      '@simplewebauthn/browser': 13.2.2
-      '@simplewebauthn/server': 13.2.2
-      better-call: 1.0.19
-      defu: 6.1.4
-      jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.0
-      zod: 4.3.6
-    optionalDependencies:
-      next: 16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - better-sqlite3
-
-  better-auth@1.5.5(better-sqlite3@12.6.2)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(mongodb@7.1.0(socks@2.8.7))(next@16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(pg@8.16.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))
-      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)
-      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))
-      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))
+      '@better-auth/core': 1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))
+      '@better-auth/kysely-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.12)
+      '@better-auth/memory-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(mongodb@7.1.0(socks@2.8.7))
+      '@better-auth/prisma-adapter': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.5(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.12)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
@@ -26632,23 +26163,15 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.6.2
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
       mongodb: 7.1.0(socks@2.8.7)
       next: 16.0.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      pg: 8.16.3
+      pg: 8.18.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@25.2.3)(happy-dom@20.6.1(bufferutil@4.1.0))(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
-
-  better-call@1.0.19:
-    dependencies:
-      '@better-auth/utils': 0.3.0
-      '@better-fetch/fetch': 1.1.18
-      rou3: 0.5.1
-      set-cookie-parser: 2.7.2
-      uncrypto: 0.1.3
 
   better-call@1.3.2(zod@3.25.76):
     dependencies:
@@ -26676,6 +26199,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   big-integer@1.6.52: {}
 
@@ -27045,7 +26569,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   chownr@2.0.0: {}
 
@@ -27931,31 +27456,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3):
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      better-sqlite3: 12.6.2
-      expo-sqlite: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0)
-      kysely: 0.28.11
-      pg: 8.16.3
-
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       better-sqlite3: 12.6.2
       expo-sqlite: 16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0)
       kysely: 0.28.12
-      pg: 8.16.3
+      pg: 8.18.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3))(zod@4.1.12):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.11)(pg@8.16.3)
-      zod: 4.1.12
-
-  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3))(zod@4.1.12):
-    dependencies:
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.16.3)
-      zod: 4.1.12
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.6.2)(expo-sqlite@16.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(bufferutil@4.1.0)(react@19.1.0))(react@19.1.0))(kysely@0.28.12)(pg@8.18.0)
+      zod: 4.3.6
 
   ds-store@0.1.6:
     dependencies:
@@ -29337,7 +28849,8 @@ snapshots:
 
   exif-parser@0.1.12: {}
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -30252,7 +29765,8 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -31203,8 +30717,6 @@ snapshots:
       jotai: 2.15.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.1.17)(react@19.1.0)
       react: 19.1.0
 
-  jose@6.1.3: {}
-
   jose@6.2.1: {}
 
   jotai@2.15.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.1.17)(react@19.1.0):
@@ -31380,8 +30892,6 @@ snapshots:
   kose-font@1.0.0: {}
 
   ky@1.14.3: {}
-
-  kysely@0.28.11: {}
 
   kysely@0.28.12: {}
 
@@ -32546,7 +32056,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mkdirp@0.5.6:
     dependencies:
@@ -32664,11 +32175,10 @@ snapshots:
 
   nanoid@5.1.6: {}
 
-  nanostores@1.1.0: {}
-
   nanostores@1.2.0: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   napi-postinstall@0.3.4: {}
 
@@ -32768,6 +32278,7 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+    optional: true
 
   node-addon-api@1.7.2:
     optional: true
@@ -33228,9 +32739,9 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.11.0(pg@8.16.3):
+  pg-pool@3.11.0(pg@8.18.0):
     dependencies:
-      pg: 8.16.3
+      pg: 8.18.0
 
   pg-protocol@1.11.0: {}
 
@@ -33242,10 +32753,10 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
-  pg@8.16.3:
+  pg@8.18.0:
     dependencies:
       pg-connection-string: 2.11.0
-      pg-pool: 3.11.0(pg@8.16.3)
+      pg-pool: 3.11.0(pg@8.18.0)
       pg-protocol: 1.11.0
       pg-types: 2.2.0
       pgpass: 1.0.5
@@ -33624,6 +33135,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -33765,18 +33277,13 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
-
-  pvtsutils@1.3.6:
-    dependencies:
-      tslib: 2.8.1
-
-  pvutils@1.1.5: {}
 
   qr.js@0.0.0: {}
 
@@ -34475,8 +33982,6 @@ snapshots:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
 
-  reflect-metadata@0.2.2: {}
-
   regenerate-unicode-properties@10.2.2:
     dependencies:
       regenerate: 1.4.2
@@ -34826,8 +34331,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  rou3@0.5.1: {}
-
   rou3@0.7.12: {}
 
   rough-notation@0.5.1: {}
@@ -35116,13 +34619,15 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   simple-git-hooks@2.13.1: {}
 
@@ -35629,6 +35134,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -35914,7 +35420,8 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tslib@1.14.1: {}
+  tslib@1.14.1:
+    optional: true
 
   tslib@2.4.1: {}
 
@@ -35956,10 +35463,6 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
-
-  tsyringe@4.10.0:
-    dependencies:
-      tslib: 1.14.1
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -36072,8 +35575,6 @@ snapshots:
       jiti: 2.6.1
       quansync: 1.0.0
       unconfig-core: 7.5.0
-
-  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 
@@ -37099,8 +36600,6 @@ snapshots:
   zod@3.22.4: {}
 
   zod@3.25.76: {}
-
-  zod@4.1.12: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ packages:
   - "!**/example/**"
 
 catalog:
-  "@follow-app/client-sdk": 0.3.92
-  "@folo-services/ai-tools": 0.2.65
+  "@follow-app/client-sdk": 0.3.95
+  "@folo-services/ai-tools": 0.2.66
   tailwindcss-uikit-colors: 1.0.0
   typescript: 5.9.3
 
@@ -40,6 +40,8 @@ overrides:
   "@floating-ui/dom": 1.7.2
   "@floating-ui/react": 0.27.14
   "@floating-ui/react-dom": 2.1.4
+  "@follow-app/client-sdk": 0.3.95
+  "@folo-services/drizzle": 0.1.47
   "@react-native-menu/menu": 2.0.0
   "@types/react": 19.1.17
   array-includes: npm:@nolyfill/array-includes@latest


### PR DESCRIPTION
### Description

This PR upgrades `@follow-app/client-sdk` to `0.3.95`, `@folo-services/drizzle` to `0.1.47`, and `@folo-services/ai-tools` to `0.2.66`, then aligns desktop, mobile, SSR, and shared store code with the released package contracts. It also removes the temporary local-link workflow and refreshes the lockfile to use published packages only. The app-side changes focus on type and API compatibility for discover analytics, wallet/profile flows, subscriptions/store state, and SSR share pages.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

Published package versions used here: `@follow-app/client-sdk@0.3.95`, `@folo-services/drizzle@0.1.47`, `@folo-services/shared@0.0.47`, `@folo-services/constants@0.1.55`, and `@folo-services/exceptions@0.1.30`.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
