### PR TITLE
fix(ssr): route dist-external assets

### DIFF
--- a/apps/ssr/worker-entry.ts
+++ b/apps/ssr/worker-entry.ts
@@ -144,6 +144,12 @@ app.get("/og/:type/:id", async (c) => {
   })
 })
 
+// SSR pages reference hashed bundles from /dist-external, so these requests
+// must stay on the SSR worker instead of falling through to the SPA worker.
+app.get("/dist-external/*", (c) => {
+  return c.env.ASSETS.fetch(c.req.raw)
+})
+
 // SSR routes - use SSR template with meta injection
 // These routes correspond to the vercel.json rewrites to follow-external-ssr
 const ssrHandler = async (c: any) => {

--- a/apps/ssr/wrangler.jsonc
+++ b/apps/ssr/wrangler.jsonc
@@ -31,6 +31,10 @@
       "zone_id": "115ea8e6a7865dbfc1cf4530d5f87f63",
     },
     {
+      "pattern": "app.folo.is/dist-external/*",
+      "zone_id": "115ea8e6a7865dbfc1cf4530d5f87f63",
+    },
+    {
       "pattern": "app.folo.is/og/*",
       "zone_id": "115ea8e6a7865dbfc1cf4530d5f87f63",
     },
@@ -81,6 +85,10 @@
       "routes": [
         {
           "pattern": "dev.folo.is/share/*",
+          "zone_id": "115ea8e6a7865dbfc1cf4530d5f87f63",
+        },
+        {
+          "pattern": "dev.folo.is/dist-external/*",
           "zone_id": "115ea8e6a7865dbfc1cf4530d5f87f63",
         },
         {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Routes `/dist-external/*` through the SSR worker so auth SSR pages can load their hashed bundles instead of receiving the SPA HTML fallback.
Adds the matching Cloudflare route entries for both `app.folo.is` and `dev.folo.is`.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

This fixes the white screen on `/login` caused by module script requests under `/dist-external/*` resolving to `text/html`.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
