### PR TITLE
fix(cli): remove delayed browser login completion

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "folocli",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Folo CLI for terminal workflows and automation",
   "author": "Folo Team",
   "license": "AGPL-3.0-only",

--- a/apps/cli/src/browser-login.test.ts
+++ b/apps/cli/src/browser-login.test.ts
@@ -1,8 +1,14 @@
+import { Agent, request } from "node:http"
+
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_VALUES } from "../../../packages/internal/shared/src/env.common"
-import { resolveBrowserLoginToken, resolveCLILoginUrl } from "./browser-login"
+import { loginWithBrowser, resolveBrowserLoginToken, resolveCLILoginUrl } from "./browser-login"
 import { CLIError } from "./output"
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}))
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -50,6 +56,91 @@ describe("browser login helpers", () => {
     expect(() => resolveCLILoginUrl("not-a-url", "http://127.0.0.1:3333/callback")).toThrowError(
       /Invalid API URL/,
     )
+  })
+
+  it("resolves browser login without waiting on a kept-alive callback socket", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session: { token: "session-token" },
+          user: { id: "user-1" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    let loginUrl: string | undefined
+    const loginPromise = loginWithBrowser({
+      apiUrl: DEFAULT_VALUES.PROD.API_URL,
+      timeoutMs: 1_000,
+      onStatus: (message) => {
+        const prefix = "Open this URL to sign in: "
+        if (message.startsWith(prefix)) {
+          loginUrl = message.slice(prefix.length)
+        }
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(loginUrl).toBeTruthy()
+    })
+
+    const callbackUrl = new URL(loginUrl!).searchParams.get("cli_callback")
+    expect(callbackUrl).toBeTruthy()
+
+    const callbackRequestUrl = new URL(callbackUrl!)
+    callbackRequestUrl.searchParams.set("token", "one-time-token")
+
+    const agent = new Agent({ keepAlive: true })
+
+    try {
+      const response = await new Promise<{ body: string; connectionHeader?: string }>(
+        (resolve, reject) => {
+          const req = request(
+            callbackRequestUrl,
+            {
+              agent,
+              headers: {
+                Connection: "keep-alive",
+              },
+            },
+            (res) => {
+              let body = ""
+              res.setEncoding("utf8")
+              res.on("data", (chunk) => {
+                body += chunk
+              })
+              res.on("end", () => {
+                const connectionHeader = Array.isArray(res.headers.connection)
+                  ? res.headers.connection[0]
+                  : res.headers.connection
+                resolve({ body, connectionHeader })
+              })
+            },
+          )
+
+          req.on("error", reject)
+          req.end()
+        },
+      )
+
+      expect(response.body).toContain("Folo CLI login complete")
+      expect(response.connectionHeader).toBe("close")
+
+      await expect(loginPromise).resolves.toEqual(
+        expect.objectContaining({
+          token: "session-token",
+          callbackUrl,
+          loginUrl,
+        }),
+      )
+    } finally {
+      agent.destroy()
+    }
   })
 
   it("exchanges one-time token for a session token", async () => {

--- a/apps/cli/src/browser-login.ts
+++ b/apps/cli/src/browser-login.ts
@@ -308,6 +308,7 @@ export const loginWithBrowser = async (
       server.close(() => {
         handler()
       })
+      server.closeIdleConnections?.()
     }
 
     const server = createServer((req, res) => {
@@ -315,6 +316,9 @@ export const loginWithBrowser = async (
         req.url ?? "/",
         `http://${req.headers.host ?? LOCAL_CALLBACK_HOST}`,
       )
+
+      res.shouldKeepAlive = false
+      res.setHeader("connection", "close")
 
       if (requestUrl.pathname !== LOCAL_CALLBACK_PATH) {
         res.statusCode = 404


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fix CLI browser login completing late after the callback page already shows success. Force the local callback response to close idle keep-alive connections, add a regression test for the kept-alive socket case, and bump `folocli` to `0.0.5`.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)

### Linked Issues

### Additional context

Reproduced with `npx --yes folocli@latest login` hanging after the browser redirected to the local `127.0.0.1` callback.

### Changelog

- [ ] I have updated the changelog/next.md with my changes.
