### PR TITLE
fix: use >= for hour-format threshold in PlayerProgress to correctly display 1:00:00

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/player/corner-player.tsx
+++ b/apps/desktop/layer/renderer/src/modules/player/corner-player.tsx
@@ -360,7 +360,7 @@ export const PlayerProgress = () => {
     return dayjs()
       .startOf("y")
       .second(time)
-      .format(time > ONE_HOUR_IN_SECONDS ? "H:mm:ss" : "m:ss")
+      .format(time >= ONE_HOUR_IN_SECONDS ? "H:mm:ss" : "m:ss")
   }
 
   const currentTimeIndicator = getTimeIndicator(controlledCurrentTime)


### PR DESCRIPTION
## Summary

Fixes #4965

## Problem

In `PlayerProgress` inside `corner-player.tsx`, the `getTimeIndicator` function uses a strict `>` comparison to decide the time format:

```ts
const ONE_HOUR_IN_SECONDS = 60 * 60

.format(time > ONE_HOUR_IN_SECONDS ? "H:mm:ss" : "m:ss")
```

When `time` is exactly `3600` seconds (1 hour), `3600 > 3600` evaluates to `false`, causing `dayjs` to format with `"m:ss"` and display `"60:00"` instead of `"1:00:00"`.

## Fix

Change `>` to `>=` so that exactly 1-hour durations are formatted correctly:

```ts
.format(time >= ONE_HOUR_IN_SECONDS ? "H:mm:ss" : "m:ss")
```

## Testing

- Play an audio track that is exactly 3600 seconds (1 hour) long
- Current time indicator should show `1:00:00` rather than `60:00`
