### PR TITLE
fix: enter and return via the "discover" route

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/subscription-column/SubscriptionColumnHeader.tsx
+++ b/apps/desktop/layer/renderer/src/modules/subscription-column/SubscriptionColumnHeader.tsx
@@ -7,7 +7,7 @@ import { m } from "motion/react"
 import type { FC, PropsWithChildren } from "react"
 import { memo, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useNavigate } from "react-router"
+import { useLocation, useNavigate } from "react-router"
 import { toast } from "sonner"
 
 import { setTimelineColumnShow, useSubscriptionColumnShow } from "~/atoms/sidebar"
@@ -28,6 +28,7 @@ export const SubscriptionColumnHeader = memo(() => {
   const timelineId = useRouteParamsSelector((s) => s.timelineId)
   const navigateBackHome = useBackHome(timelineId)
   const navigate = useNavigate()
+  const location = useLocation()
   const normalStyle = !window.electron || window.electron.process.platform !== "darwin"
   const { t } = useTranslation()
   return (
@@ -57,7 +58,11 @@ export const SubscriptionColumnHeader = memo(() => {
           data-testid="subscription-discover-trigger"
           shortcut="$mod+T"
           tooltip={t("words.discover")}
-          onClick={() => navigate("/discover")}
+          onClick={() => {
+            if (location.pathname !== "/discover") {
+              navigate("/discover")
+            }
+          }}
         >
           <i className="i-mgc-add-cute-re size-5 text-text-secondary" />
         </ActionButton>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
when clicking into the discover page multiple times, the return also requires multiple clicks
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

### Demo Video (if new feature)


https://github.com/user-attachments/assets/8647762c-4839-4bf9-b5be-5b03847b81c3



### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [ ] I have updated the changelog/next.md with my changes.
