### PR TITLE
fix: dedupe code blocks with nested line divs

### DIFF
--- a/apps/desktop/changelog/next.md
+++ b/apps/desktop/changelog/next.md
@@ -6,6 +6,8 @@
 
 ## No longer broken
 
+- Fixed duplicated lines in code blocks from feeds that wrap each line in nested divs (e.g., Cloudflare's changelog)
+
 ## Thanks
 
 Special thanks to volunteer contributors @ for their valuable contributions

--- a/apps/desktop/layer/renderer/src/lib/__tests__/parse-html.test.ts
+++ b/apps/desktop/layer/renderer/src/lib/__tests__/parse-html.test.ts
@@ -365,6 +365,20 @@ describe("extractCodeFromHtml", () => {
     `)
   })
 
+  // https://developers.cloudflare.com/changelog/rss/index.xml
+  it("should not duplicate code blocks from cloudflare changelog", () => {
+    const htmlString = `<div><div><span>{</span></div></div><div><div><span>  </span><span>"</span><span>$schema</span><span>"</span><span>:</span><span> </span><span>"./node_modules/wrangler/config-schema.json"</span><span>,</span></div></div><div><div><span>  </span><span>"</span><span>pipelines</span><span>"</span><span>:</span><span> </span><span>[</span></div></div><div><div><span>}</span></div></div>`
+    const result = extractCodeFromHtml(htmlString)
+
+    expect(result).toMatchInlineSnapshot(`
+      "{
+        "$schema": "./node_modules/wrangler/config-schema.json",
+        "pipelines": [
+      }
+      "
+    `)
+  })
+
   it("no <code />", () => {
     const htmlString = `<span class="line"><span class="keyword">if</span> theme.<span class="property">twikoo</span>.<span class="property">enable</span> == <span class="literal">true</span></span><br><span class="line">  #tcomment</span><br><span class="line">  <span class="title function_">script</span>(src=<span class="string">'https://registry.npmmirror.com/twikoo/1.6.39/files/dist/twikoo.all.min.js'</span>)</span><br><span class="line">  script.</span><br><span class="line">    twikoo.<span class="title function_">init</span>({</span><br><span class="line">      <span class="attr">envId</span>: <span class="string">'#{theme.twikoo.envId}'</span>,</span><br><span class="line">      <span class="attr">el</span>: <span class="string">'#tcomment'</span>,</span><br><span class="line">      <span class="attr">region</span>: <span class="string">'#{theme.twikoo.region}'</span>,</span><br><span class="line">      <span class="attr">path</span>: <span class="string">'#{theme.twikoo.path}'</span>,</span><br><span class="line">      <span class="attr">onCommentLoaded</span>: <span class="keyword">function</span> (<span class="params"></span>) {</span><br><span class="line">        <span class="keyword">const</span> commentCountElement = <span class="variable language_">document</span>.<span class="title function_">querySelector</span>(<span class="string">'.tk-comments-count'</span>);</span><br><span class="line">        <span class="keyword">const</span> targetElement = <span class="variable language_">document</span>.<span class="title function_">querySelector</span>(<span class="string">'.waline-comment-count'</span>);</span><br><span class="line">        <span class="keyword">if</span> (commentCountElement) {</span><br><span class="line">          <span class="keyword">const</span> countSpan = commentCountElement.<span class="title function_">querySelector</span>(<span class="string">'span:first-child'</span>);</span><br><span class="line">          <span class="keyword">const</span> commentCount = <span class="built_in">parseInt</span>(countSpan.<span class="property">textContent</span>);</span><br><span class="line">          targetElement.<span class="property">textContent</span> = commentCount;</span><br><span class="line">        } <span class="keyword">else</span> {</span><br><span class="line">          <span class="variable language_">console</span>.<span class="title function_">log</span>(<span class="string">'未找到评论数量元素'</span>);</span><br><span class="line">        }</span><br><span class="line">      }</span><br><span class="line">    })</span><br><span class="line"></span><br>`
     const result = extractCodeFromHtml(htmlString)

--- a/apps/desktop/layer/renderer/src/lib/parse-html.ts
+++ b/apps/desktop/layer/renderer/src/lib/parse-html.ts
@@ -269,7 +269,9 @@ export function extractCodeFromHtml(htmlString: string) {
 
   if (divElements.length > 0) {
     divElements.forEach((div) => {
-      code += `${div.textContent}\n`
+      if (!div.querySelector("div")) {
+        code += `${div.textContent}\n`
+      }
     })
     return code
   }

--- a/apps/mobile/changelog/next.md
+++ b/apps/mobile/changelog/next.md
@@ -6,6 +6,8 @@
 
 ## No longer broken
 
+- Fixed duplicated lines in code blocks from feeds that wrap each line in nested divs (e.g., Cloudflare's changelog)
+
 ## Thanks
 
 Special thanks to volunteer contributors @ for their valuable contributions

--- a/apps/mobile/web-app/html-renderer/src/parser.tsx
+++ b/apps/mobile/web-app/html-renderer/src/parser.tsx
@@ -197,7 +197,9 @@ function extractCodeFromHtml(htmlString: string) {
 
   if (divElements.length > 0) {
     divElements.forEach((div) => {
-      code += `${div.textContent}\n`
+      if (!div.querySelector("div")) {
+        code += `${div.textContent}\n`
+      }
     })
     return code
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixed duplicated lines in code blocks from feeds that wrap each line in nested divs (e.g., Cloudflare's changelog) https://developers.cloudflare.com/changelog/rss/index.xml

### PR Type

<!-- Please check the type of PR: -->

- [ ] Feature
- [x] Bugfix
- [ ] Hotfix
- [ ] Other (please describe):

### Screenshots (if UI change)

<img width="1440" height="1462" alt="code-block" src="https://github.com/user-attachments/assets/d5f0d343-951b-4af9-8636-0c234fb07cc7" />

### Demo Video (if new feature)

N/A

### Linked Issues

N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

`extractCodeFromHtml` is exactly the same in both desktop and mobile, which should be merged into a shared code.

### Changelog

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix: -->

- [x] I have updated the changelog/next.md with my changes.
