### PR TITLE
docs: add regex help for action conditions

### DIFF
--- a/apps/desktop/layer/renderer/src/modules/action/when-section.tsx
+++ b/apps/desktop/layer/renderer/src/modules/action/when-section.tsx
@@ -105,6 +105,7 @@ export const WhenSection = ({ index }: WhenSectionProps) => {
                           />
                           <ValueInput
                             type={type}
+                            operator={item.operator}
                             value={item.value}
                             onChange={(value) => change("value", value)}
                             disabled={disabled}
@@ -211,15 +212,19 @@ const OperationSelect = ({
 
 const ValueInput = ({
   type,
+  operator,
   value,
   onChange,
   disabled,
 }: {
   type: string
+  operator?: ActionOperation
   value?: string | number
   onChange: (value: string | number) => void
   disabled?: boolean
 }) => {
+  const { t } = useTranslation("settings")
+
   switch (type) {
     case "view": {
       return (
@@ -264,12 +269,19 @@ const ValueInput = ({
     }
     default: {
       return (
-        <Input
-          disabled={disabled}
-          value={value as string | undefined}
-          className="h-9"
-          onChange={(event) => onChange(event.target.value)}
-        />
+        <div className="flex flex-col gap-1.5 @[800px]:flex-1">
+          <Input
+            disabled={disabled}
+            value={value as string | undefined}
+            className="h-9"
+            onChange={(event) => onChange(event.target.value)}
+          />
+          {operator === "regex" && (
+            <p className="text-xs leading-relaxed text-text-tertiary">
+              {t("actions.action_card.regex_help")}
+            </p>
+          )}
+        </div>
       )
     }
   }

--- a/locales/settings/en.json
+++ b/locales/settings/en.json
@@ -68,6 +68,7 @@
   "actions.action_card.operation_options.matches_regex": "Matches Regex",
   "actions.action_card.operator": "Operator",
   "actions.action_card.or": "Or",
+  "actions.action_card.regex_help": "Regex pattern example: (car|bottle|people). Escape special characters when you want to match them literally.",
   "actions.action_card.rewrite_rules": "Rewrite Rules",
   "actions.action_card.settings": "Settings",
   "actions.action_card.silence": "Silence",

--- a/locales/settings/fr-FR.json
+++ b/locales/settings/fr-FR.json
@@ -68,6 +68,7 @@
   "actions.action_card.operation_options.matches_regex": "Correspond à l'expression régulière",
   "actions.action_card.operator": "Opérateur",
   "actions.action_card.or": "Ou",
+  "actions.action_card.regex_help": "Exemple de regex : (car|bottle|people). Échappez les caractères spéciaux pour les faire correspondre littéralement.",
   "actions.action_card.rewrite_rules": "Règles de réécriture",
   "actions.action_card.settings": "Paramètres",
   "actions.action_card.silence": "Silence",

--- a/locales/settings/ja.json
+++ b/locales/settings/ja.json
@@ -68,6 +68,7 @@
   "actions.action_card.operation_options.matches_regex": "正規表現に一致する",
   "actions.action_card.operator": "オペレーター",
   "actions.action_card.or": "または",
+  "actions.action_card.regex_help": "正規表現の例: (car|bottle|people)。特殊文字を文字として一致させる場合はエスケープしてください。",
   "actions.action_card.rewrite_rules": "リライトルール",
   "actions.action_card.settings": "設定",
   "actions.action_card.silence": "サイレント",

--- a/locales/settings/zh-CN.json
+++ b/locales/settings/zh-CN.json
@@ -68,6 +68,7 @@
   "actions.action_card.operation_options.matches_regex": "匹配正则表达式",
   "actions.action_card.operator": "运算符",
   "actions.action_card.or": "或者",
+  "actions.action_card.regex_help": "正则表达式示例：(car|bottle|people)。如果要按字面量匹配特殊字符，请进行转义。",
   "actions.action_card.rewrite_rules": "重写规则",
   "actions.action_card.settings": "设置",
   "actions.action_card.silence": "静音",

--- a/locales/settings/zh-TW.json
+++ b/locales/settings/zh-TW.json
@@ -68,6 +68,7 @@
   "actions.action_card.operation_options.matches_regex": "符合正規表達式",
   "actions.action_card.operator": "運算子",
   "actions.action_card.or": "或",
+  "actions.action_card.regex_help": "正規表示式範例：(car|bottle|people)。如果要按字面量比對特殊字元，請進行跳脫。",
   "actions.action_card.rewrite_rules": "重寫規則",
   "actions.action_card.settings": "設置",
   "actions.action_card.silence": "靜音",


### PR DESCRIPTION
## Summary

- Add inline help when an action condition uses the regex operator
- Include a concrete regex example for notification/action rules
- Add the new help text to existing settings locale files

Closes #5000

## Test Plan

- `git diff --check`
- `pnpm exec eslint apps/desktop/layer/renderer/src/modules/action/when-section.tsx locales/settings/en.json locales/settings/fr-FR.json locales/settings/ja.json locales/settings/zh-CN.json locales/settings/zh-TW.json`
- `pnpm exec prettier --check apps/desktop/layer/renderer/src/modules/action/when-section.tsx locales/settings/en.json locales/settings/fr-FR.json locales/settings/ja.json locales/settings/zh-CN.json locales/settings/zh-TW.json`
- `pnpm --dir apps/desktop/layer/renderer run typecheck`
- `pnpm --dir apps/desktop/layer/renderer run test -- --run`
